### PR TITLE
feat:Add support for bool in WireFormat

### DIFF
--- a/components/jetstream_wireformat/src/lib.rs
+++ b/components/jetstream_wireformat/src/lib.rs
@@ -280,6 +280,29 @@ impl WireFormat for () {
     }
 }
 
+impl WireFormat for bool {
+    fn byte_size(&self) -> u32 {
+        1
+    }
+
+    fn encode<W: Write>(&self, writer: &mut W) -> io::Result<()> {
+        writer.write_all(&[*self as u8])
+    }
+
+    fn decode<R: Read>(reader: &mut R) -> io::Result<Self> {
+        let mut byte = [0u8; 1];
+        reader.read_exact(&mut byte)?;
+        match byte[0] {
+            0 => Ok(false),
+            1 => Ok(true),
+            _ => Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "invalid byte for bool",
+            )),
+        }
+    }
+}
+
 impl io::Read for Data {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         self.0.reader().read(buf)

--- a/tests/wire_format.rs
+++ b/tests/wire_format.rs
@@ -717,3 +717,35 @@ fn test_nested_option() {
     let decoded: Option<Option<u32>> = WireFormat::decode(&mut cursor).unwrap();
     assert_eq!(value, decoded);
 }
+
+#[test]
+fn test_bool_encode() {
+    let mut buf = Vec::new();
+    true.encode(&mut buf).unwrap();
+    assert_eq!(buf, vec![1]);
+
+    buf.clear();
+    false.encode(&mut buf).unwrap();
+    assert_eq!(buf, vec![0]);
+}
+
+#[test]
+fn test_bool_decode() {
+    let mut cursor = Cursor::new(vec![1]);
+    let decoded: bool = WireFormat::decode(&mut cursor).unwrap();
+    assert_eq!(decoded, true);
+
+    cursor = Cursor::new(vec![0]);
+    let decoded: bool = WireFormat::decode(&mut cursor).unwrap();
+    assert_eq!(decoded, false);
+}
+
+#[test]
+fn test_bool_invalid_decode() {
+    let mut cursor = Cursor::new(vec![2]);
+    let result: Result<bool, _> = WireFormat::decode(&mut cursor);
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert_eq!(e.kind(), io::ErrorKind::InvalidData);
+    }
+}


### PR DESCRIPTION
Add support for encoding and decoding `bool` values in Jetstream wireformat.

* **WireFormat Implementation for bool**
  - Implement `WireFormat` for `bool` to encode/decode as a single byte in `components/jetstream_wireformat/src/lib.rs`.
  - Add methods to calculate byte size, encode, and decode `bool` values.

* **Unit Tests**
  - Add unit tests for encoding and decoding `bool` values in `tests/wire_format.rs`.
  - Include tests for valid `bool` values (true and false) and invalid byte values.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/sevki/jetstream/pull/176?shareId=e3e256f8-2c29-419f-93cb-dea77282e006).