### PR TITLE
Fix byte_size validation in Frame::decode

### DIFF
--- a/components/jetstream_rpc/src/lib.rs
+++ b/components/jetstream_rpc/src/lib.rs
@@ -129,10 +129,12 @@ impl<T: Framer> WireFormat for Frame<T> {
         // byte_size includes the size of byte_size so remove that from the
         // expected length of the message.  Also make sure that byte_size is at least
         // that long to begin with.
-        if byte_size < mem::size_of::<u32>() as u32 {
+        let header_size =
+            mem::size_of::<u32>() + mem::size_of::<u8>() + mem::size_of::<u16>();
+        if byte_size < header_size as u32 {
             return Err(io::Error::new(
                 ErrorKind::InvalidData,
-                format!("byte_size(= {}) is less than 4 bytes", byte_size),
+                format!("byte_size(= {}) is less than {} bytes", byte_size, header_size),
             ));
         }
         let reader =

--- a/tests/rpc_frame.rs
+++ b/tests/rpc_frame.rs
@@ -1,0 +1,24 @@
+use std::io::Cursor;
+
+use jetstream_rpc::{Frame, Framer};
+use jetstream_wireformat::WireFormat;
+
+#[derive(Clone)]
+struct Dummy;
+
+impl Framer for Dummy {
+    fn message_type(&self) -> u8 { 0 }
+    fn byte_size(&self) -> u32 { 0 }
+    fn encode<W: std::io::Write>(&self, _: &mut W) -> std::io::Result<()> { Ok(()) }
+    fn decode<R: std::io::Read>(_: &mut R, _: u8) -> std::io::Result<Self> { Ok(Dummy) }
+}
+
+#[test]
+fn reject_too_small_byte_size() {
+    let mut data = Vec::new();
+    // byte_size smaller than header (should be 7 bytes)
+    4u32.encode(&mut data).unwrap();
+    // missing rest of header and body
+    let res = Frame::<Dummy>::decode(&mut Cursor::new(data));
+    assert!(res.is_err());
+}


### PR DESCRIPTION
## Summary
- ensure JetStream RPC frame decoding checks full header size
- add test for short byte_size handling

## Testing
- `cargo test --test rpc_frame --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6846b127e8808323b5b8a1995a5899e2