### PR TITLE
chore: give each component crate its own README

### DIFF
--- a/components/jetstream_9p/Cargo.toml
+++ b/components/jetstream_9p/Cargo.toml
@@ -5,7 +5,7 @@ edition = { workspace = true }
 description = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
-readme = { workspace = true }
+readme = "README.md"
 documentation.workspace = true
 [lib]
 bench = false

--- a/components/jetstream_9p/README.md
+++ b/components/jetstream_9p/README.md
@@ -1,0 +1,3 @@
+# jetstream_9p
+
+Part of [jetstream](https://github.com/sevki/jetstream).

--- a/components/jetstream_codegen/Cargo.toml
+++ b/components/jetstream_codegen/Cargo.toml
@@ -4,7 +4,7 @@ version = "16.3.0"
 edition.workspace = true
 description.workspace = true
 documentation.workspace = true
-readme.workspace = true
+readme = "README.md"
 repository.workspace = true
 license.workspace = true
 

--- a/components/jetstream_codegen/README.md
+++ b/components/jetstream_codegen/README.md
@@ -1,0 +1,3 @@
+# jetstream_codegen
+
+Part of [jetstream](https://github.com/sevki/jetstream).

--- a/components/jetstream_error/Cargo.toml
+++ b/components/jetstream_error/Cargo.toml
@@ -4,7 +4,7 @@ version = "16.3.0"
 edition.workspace = true
 description.workspace = true
 documentation.workspace = true
-readme.workspace = true
+readme = "README.md"
 repository.workspace = true
 license.workspace = true
 

--- a/components/jetstream_error/README.md
+++ b/components/jetstream_error/README.md
@@ -1,0 +1,3 @@
+# jetstream_error
+
+Part of [jetstream](https://github.com/sevki/jetstream).

--- a/components/jetstream_http/Cargo.toml
+++ b/components/jetstream_http/Cargo.toml
@@ -4,7 +4,7 @@ version = "16.3.0"
 edition.workspace = true
 description.workspace = true
 documentation.workspace = true
-readme.workspace = true
+readme = "README.md"
 repository.workspace = true
 license.workspace = true
 

--- a/components/jetstream_http/README.md
+++ b/components/jetstream_http/README.md
@@ -1,0 +1,3 @@
+# jetstream_http
+
+Part of [jetstream](https://github.com/sevki/jetstream).

--- a/components/jetstream_iroh/Cargo.toml
+++ b/components/jetstream_iroh/Cargo.toml
@@ -6,7 +6,7 @@ description.workspace = true
 license.workspace = true
 repository.workspace = true
 documentation.workspace = true
-readme.workspace = true
+readme = "README.md"
 
 [dependencies]
 async-trait = "0.1.89"

--- a/components/jetstream_iroh/README.md
+++ b/components/jetstream_iroh/README.md
@@ -1,0 +1,3 @@
+# jetstream_iroh
+
+Part of [jetstream](https://github.com/sevki/jetstream).

--- a/components/jetstream_libc/Cargo.toml
+++ b/components/jetstream_libc/Cargo.toml
@@ -5,7 +5,7 @@ edition = { workspace = true }
 description = "Platform-specific libc bindings for jetstream"
 license = { workspace = true }
 repository = { workspace = true }
-readme = { workspace = true }
+readme = "README.md"
 documentation.workspace = true
 
 [lib]

--- a/components/jetstream_libc/README.md
+++ b/components/jetstream_libc/README.md
@@ -1,0 +1,3 @@
+# jetstream_libc
+
+Part of [jetstream](https://github.com/sevki/jetstream).

--- a/components/jetstream_macros/Cargo.toml
+++ b/components/jetstream_macros/Cargo.toml
@@ -5,7 +5,7 @@ edition = { workspace = true }
 description = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
-readme = { workspace = true }
+readme = "README.md"
 documentation = { workspace = true }
 [dependencies]
 syn = { version = "2.0.117", features = ["full", "extra-traits"] }

--- a/components/jetstream_macros/README.md
+++ b/components/jetstream_macros/README.md
@@ -1,0 +1,3 @@
+# jetstream_macros
+
+Part of [jetstream](https://github.com/sevki/jetstream).

--- a/components/jetstream_quic/Cargo.toml
+++ b/components/jetstream_quic/Cargo.toml
@@ -6,7 +6,7 @@ description.workspace = true
 license.workspace = true
 repository.workspace = true
 documentation.workspace = true
-readme.workspace = true
+readme = "README.md"
 
 [dependencies]
 h3-quinn = { version = "0.0.10", features = ["datagram", "tracing"] }

--- a/components/jetstream_quic/README.md
+++ b/components/jetstream_quic/README.md
@@ -1,0 +1,3 @@
+# jetstream_quic
+
+Part of [jetstream](https://github.com/sevki/jetstream).

--- a/components/jetstream_rpc/Cargo.toml
+++ b/components/jetstream_rpc/Cargo.toml
@@ -5,7 +5,7 @@ edition = { workspace = true }
 description = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
-readme = { workspace = true }
+readme = "README.md"
 documentation.workspace = true
 
 

--- a/components/jetstream_rpc/README.md
+++ b/components/jetstream_rpc/README.md
@@ -1,0 +1,3 @@
+# jetstream_rpc
+
+Part of [jetstream](https://github.com/sevki/jetstream).

--- a/components/jetstream_ufs/Cargo.toml
+++ b/components/jetstream_ufs/Cargo.toml
@@ -5,7 +5,7 @@ edition = { workspace = true }
 description = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
-readme = { workspace = true }
+readme = "README.md"
 documentation.workspace = true
 
 [dependencies]

--- a/components/jetstream_ufs/README.md
+++ b/components/jetstream_ufs/README.md
@@ -1,0 +1,3 @@
+# jetstream_ufs
+
+Part of [jetstream](https://github.com/sevki/jetstream).

--- a/components/jetstream_wireformat/Cargo.toml
+++ b/components/jetstream_wireformat/Cargo.toml
@@ -5,7 +5,7 @@ edition = { workspace = true }
 description = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
-readme = { workspace = true }
+readme = "README.md"
 documentation.workspace = true
 
 

--- a/components/jetstream_wireformat/README.md
+++ b/components/jetstream_wireformat/README.md
@@ -1,0 +1,3 @@
+# jetstream_wireformat
+
+Part of [jetstream](https://github.com/sevki/jetstream).


### PR DESCRIPTION
`workspace.package.readme` is `README.md`, and an inherited `readme` resolves relative to the **package** directory, not the workspace root. Every component crate inherited a path that does not exist next to its own `Cargo.toml`.

Adds a minimal README to each of the eleven component crates and points `readme` at it explicitly.

Mechanical: 11 new three-line files, and one line changed per `Cargo.toml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)