### PR TITLE
feat(rpc): draft the session and lane model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2895,9 +2895,11 @@ dependencies = [
 name = "jetstream_iroh"
 version = "16.1.3"
 dependencies = [
+ "async-trait",
  "futures",
  "iroh",
  "jetstream_rpc",
+ "jetstream_wireformat",
  "lazy_static",
  "pkarr",
  "tokio",

--- a/components/jetstream_iroh/Cargo.toml
+++ b/components/jetstream_iroh/Cargo.toml
@@ -9,7 +9,9 @@ documentation.workspace = true
 readme.workspace = true
 
 [dependencies]
+async-trait = "0.1.89"
 futures = "0.3.32"
+jetstream_wireformat = { version = "16.1.3", path = "../jetstream_wireformat" }
 jetstream_rpc = { version = "16.1.3", path = "../jetstream_rpc", features = [
   "iroh",
 ] }

--- a/components/jetstream_iroh/src/lib.rs
+++ b/components/jetstream_iroh/src/lib.rs
@@ -7,6 +7,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 mod client;
 mod server;
+mod session;
 
 use std::fmt::Debug;
 
@@ -19,8 +20,9 @@ use iroh::{
     protocol::Router,
     EndpointAddr, RelayConfig, RelayMap, RelayUrl,
 };
-use jetstream_rpc::{server::Server, Protocol};
+use jetstream_rpc::{server::Server, session::Session, Protocol};
 pub use server::{IrohRouter, IrohServer};
+pub use session::{IrohServiceLane, IrohSession};
 
 pub extern crate iroh;
 
@@ -47,16 +49,37 @@ pub fn endpoint_builder<P: Protocol>() -> iroh::endpoint::Builder {
         .address_lookup(jetstream_resolver())
 }
 
-pub async fn client_builder<P: Protocol>(
+/// r[impl jetstream.session.conformance.iroh]
+/// Dial `addr` and keep the connection as a session, so the caller can
+/// open as many lanes as it wants rather than being handed one.
+pub async fn session_builder<P: Protocol>(
     addr: EndpointAddr,
-) -> Result<client::IrohTransport<P>, Box<dyn std::error::Error + 'static>> {
+) -> Result<IrohSession<P>, Box<dyn std::error::Error + 'static>> {
     let endpoint = endpoint_builder::<P>().bind().await.map_err(Box::new)?;
     let conn = endpoint
         .connect(addr, P::NAME.as_bytes())
         .await
         .map_err(Box::new)?;
-    let streams = conn.open_bi().await?;
-    Ok(IrohTransport::new_owned(streams, conn, endpoint))
+    Ok(IrohSession::new_owned(conn, endpoint))
+}
+
+/// Dial `addr` and open one lane on it.
+///
+/// r[impl jetstream.session.compat.existing-clients]
+/// This is the pre-session shape: one lane, tag-multiplexed by whatever
+/// the caller wraps it in. It stays conforming, and is now a session
+/// with one lane opened on it rather than a connection with its extra
+/// lanes thrown away — the lane keeps the session alive, so a caller
+/// that wants a second lane can ask for a session instead.
+pub async fn client_builder<P>(
+    addr: EndpointAddr,
+) -> Result<client::IrohTransport<P>, Box<dyn std::error::Error + 'static>>
+where
+    P: Protocol<Error = jetstream_rpc::Error> + 'static,
+{
+    let session = session_builder::<P>(addr).await?;
+    let lane = session.open_lane().await.map_err(Box::new)?;
+    Ok(lane)
 }
 
 pub async fn server_builder<P: Server + Protocol + Debug + Clone + 'static>(

--- a/components/jetstream_iroh/src/lib.rs
+++ b/components/jetstream_iroh/src/lib.rs
@@ -20,7 +20,7 @@ use iroh::{
     protocol::Router,
     EndpointAddr, RelayConfig, RelayMap, RelayUrl,
 };
-use jetstream_rpc::{server::Server, session::Session, Protocol};
+use jetstream_rpc::{server::Server, Protocol};
 pub use server::{IrohRouter, IrohServer};
 pub use session::{IrohServiceLane, IrohSession};
 
@@ -67,19 +67,22 @@ pub async fn session_builder<P: Protocol>(
 ///
 /// r[impl jetstream.session.compat.existing-clients]
 /// This is the pre-session shape: one lane, tag-multiplexed by whatever
-/// the caller wraps it in. It stays conforming, and is now a session
-/// with one lane opened on it rather than a connection with its extra
-/// lanes thrown away — the lane keeps the session alive, so a caller
-/// that wants a second lane can ask for a session instead.
-pub async fn client_builder<P>(
+/// the caller wraps it in, and it stays conforming. Its bound is
+/// deliberately just `P: Protocol` — the returned lane never touches
+/// `P::Error`, so routing it through [`IrohSession`], whose service side
+/// does, would narrow this signature and break callers whose protocol
+/// carries its own error type. Callers that want more than one lane ask
+/// for a session with [`session_builder`] instead.
+pub async fn client_builder<P: Protocol>(
     addr: EndpointAddr,
-) -> Result<client::IrohTransport<P>, Box<dyn std::error::Error + 'static>>
-where
-    P: Protocol<Error = jetstream_rpc::Error> + 'static,
-{
-    let session = session_builder::<P>(addr).await?;
-    let lane = session.open_lane().await.map_err(Box::new)?;
-    Ok(lane)
+) -> Result<client::IrohTransport<P>, Box<dyn std::error::Error + 'static>> {
+    let endpoint = endpoint_builder::<P>().bind().await.map_err(Box::new)?;
+    let conn = endpoint
+        .connect(addr, P::NAME.as_bytes())
+        .await
+        .map_err(Box::new)?;
+    let streams = conn.open_bi().await?;
+    Ok(IrohTransport::new_owned(streams, conn, endpoint))
 }
 
 pub async fn server_builder<P: Server + Protocol + Debug + Clone + 'static>(

--- a/components/jetstream_iroh/src/session.rs
+++ b/components/jetstream_iroh/src/session.rs
@@ -11,6 +11,7 @@
 use std::{
     marker::PhantomData,
     pin::Pin,
+    sync::Arc,
     task::{Context as TaskContext, Poll},
 };
 
@@ -22,12 +23,9 @@ use iroh::{
 use jetstream_rpc::{
     context::{Context, Contextual, NodeId},
     server::ServerCodec,
-    session::{
-        check_datagram_size, Capabilities, Datagrams, Session, SessionError,
-    },
+    session::{Capabilities, Datagrams, Session, SessionError},
     Error, Frame, IntoError, Protocol,
 };
-use jetstream_wireformat::WireFormat;
 use tokio_util::{
     bytes::Bytes,
     codec::{FramedRead, FramedWrite},
@@ -38,27 +36,76 @@ use crate::IrohTransport;
 /// The code an iroh connection is closed with when its session closes.
 const SESSION_CLOSED: u32 = 0;
 
-/// A JetStream session over an iroh connection.
+/// What every handle on one session shares.
 ///
-/// Cloning the session is cheap and every clone addresses the same
-/// connection, so lanes can be opened from several tasks at once.
-#[derive(Debug, Clone)]
-pub struct IrohSession<P: Protocol> {
+/// r[impl jetstream.session.lifetime]
+/// A lane must not outlive its session, and every lane carries its own
+/// clone of the connection — deliberately, so iroh does not tear the
+/// connection down under a live stream. Those clones would keep the
+/// association up after the session that made it had gone, so the
+/// connection lives here and the last handle away closes it.
+#[derive(Debug)]
+struct SessionInner {
     connection: Connection,
     // Held for as long as the session is, for the same reason
     // `IrohTransport` holds them: iroh tears the connection down
     // ungracefully if the `Endpoint` is dropped while streams opened
     // from it are still in use.
     endpoint: Option<Endpoint>,
+}
+
+impl Drop for SessionInner {
+    /// r[impl jetstream.session.lifetime]
+    /// A session that goes away during unwinding, rather than through
+    /// `close`, ends its lanes just the same.
+    fn drop(&mut self) {
+        self.connection
+            .close(VarInt::from_u32(SESSION_CLOSED), b"session dropped");
+    }
+}
+
+/// A JetStream session over an iroh connection.
+///
+/// Cloning the session is cheap and every clone addresses the same
+/// connection, so lanes can be opened from several tasks at once. The
+/// connection closes when the last clone goes away.
+pub struct IrohSession<P: Protocol> {
+    inner: Arc<SessionInner>,
     _p: PhantomData<fn() -> P>,
+}
+
+// Written out rather than derived: a derive would require `P: Clone`
+// and `P: Debug`, which a session neither holds nor needs — the
+// protocol appears only as a `PhantomData` marker.
+impl<P: Protocol> Clone for IrohSession<P> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            _p: PhantomData,
+        }
+    }
+}
+
+impl<P: Protocol> std::fmt::Debug for IrohSession<P> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("IrohSession")
+            .field("connection", &self.inner.connection)
+            .finish_non_exhaustive()
+    }
 }
 
 impl<P: Protocol> IrohSession<P> {
     /// Wrap a connection whose endpoint the caller keeps alive.
+    ///
+    /// The session takes ownership of the connection's lifetime: when
+    /// the last handle is dropped the connection closes, even if the
+    /// caller holds a clone of it.
     pub fn new(connection: Connection) -> Self {
         Self {
-            connection,
-            endpoint: None,
+            inner: Arc::new(SessionInner {
+                connection,
+                endpoint: None,
+            }),
             _p: PhantomData,
         }
     }
@@ -66,15 +113,17 @@ impl<P: Protocol> IrohSession<P> {
     /// Wrap a connection and keep `endpoint` alive alongside it.
     pub fn new_owned(connection: Connection, endpoint: Endpoint) -> Self {
         Self {
-            connection,
-            endpoint: Some(endpoint),
+            inner: Arc::new(SessionInner {
+                connection,
+                endpoint: Some(endpoint),
+            }),
             _p: PhantomData,
         }
     }
 
     /// The underlying connection.
     pub fn connection(&self) -> &Connection {
-        &self.connection
+        &self.inner.connection
     }
 }
 
@@ -95,7 +144,7 @@ where
     /// iroh establishes the peer's public key during the handshake, so
     /// the identity is available without the peer asserting anything.
     fn context(&self) -> Context {
-        Context::from(NodeId::from(self.connection.remote_id()))
+        Context::from(NodeId::from(self.inner.connection.remote_id()))
     }
 
     /// r[impl jetstream.lane.independence]
@@ -103,15 +152,16 @@ where
     /// does not delay another's.
     async fn open_lane(&self) -> Result<Self::ClientLane, SessionError> {
         let streams = self
+            .inner
             .connection
             .open_bi()
             .await
             .map_err(|err| SessionError::Transport(err.into_error()))?;
 
-        Ok(match &self.endpoint {
+        Ok(match &self.inner.endpoint {
             Some(endpoint) => IrohTransport::new_owned(
                 streams,
-                self.connection.clone(),
+                self.inner.connection.clone(),
                 endpoint.clone(),
             ),
             None => IrohTransport::from(streams),
@@ -123,6 +173,7 @@ where
     /// that accepts is not doing anything unusual.
     async fn accept_lane(&self) -> Result<Self::ServiceLane, SessionError> {
         let (send_stream, recv_stream) = self
+            .inner
             .connection
             .accept_bi()
             .await
@@ -140,69 +191,46 @@ where
     /// terminate with the session rather than outliving it, and calls in
     /// flight on them fail rather than hang.
     async fn close(&self) {
-        self.connection
+        self.inner
+            .connection
             .close(VarInt::from_u32(SESSION_CLOSED), b"session closed");
     }
 }
 
 /// r[impl jetstream.session.datagrams]
 /// iroh carries QUIC datagrams, which belong to the connection and not
-/// to any stream on it.
+/// to any stream on it. Only the raw channel is bound here; framing is
+/// the model's, so both peers agree on it.
 #[async_trait::async_trait]
 impl<P> Datagrams<P> for IrohSession<P>
 where
     P: Protocol<Error = Error> + 'static,
+    P::Request: 'static,
+    P::Response: 'static,
 {
     fn max_datagram_size(&self) -> Option<u32> {
-        self.connection
+        self.inner
+            .connection
             .max_datagram_size()
             .map(|size| size.min(u32::MAX as usize) as u32)
     }
 
-    async fn send_datagram(
+    async fn send_datagram_bytes(
         &self,
-        frame: Frame<P::Request>,
+        bytes: Bytes,
     ) -> Result<(), SessionError> {
-        // r[impl jetstream.session.datagrams]
-        // Rejected here rather than fragmented.
-        check_datagram_size(&frame, self.max_datagram_size())?;
-
-        let mut buf = Vec::with_capacity(frame.byte_size() as usize);
-        frame
-            .encode(&mut buf)
-            .map_err(|err| SessionError::Transport(Error::from(err)))?;
-
-        self.connection
-            .send_datagram(Bytes::from(buf))
+        self.inner
+            .connection
+            .send_datagram(bytes)
             .map_err(|err| SessionError::Transport(err.into_error()))
     }
 
-    async fn recv_datagram(&self) -> Result<Frame<P::Response>, SessionError> {
-        let datagram = self
+    async fn recv_datagram_bytes(&self) -> Result<Bytes, SessionError> {
+        self.inner
             .connection
             .read_datagram()
             .await
-            .map_err(|err| SessionError::Transport(err.into_error()))?;
-
-        // r[impl jetstream.session.datagrams]
-        // A datagram carries a complete frame or it is discarded; there
-        // is nothing to reassemble it from. Trailing bytes after the
-        // frame mean it is not a complete frame either — decoding would
-        // succeed on the prefix and hand back something the peer never
-        // sent.
-        let mut reader = std::io::Cursor::new(datagram.as_ref());
-        let frame = Frame::<P::Response>::decode(&mut reader)
-            .map_err(|err| SessionError::Transport(Error::from(err)))?;
-
-        let consumed = reader.position() as usize;
-        if consumed != datagram.len() {
-            return Err(SessionError::Transport(Error::new(format!(
-                "datagram has {} trailing bytes after the frame",
-                datagram.len() - consumed
-            ))));
-        }
-
-        Ok(frame)
+            .map_err(|err| SessionError::Transport(err.into_error()))
     }
 }
 

--- a/components/jetstream_iroh/src/session.rs
+++ b/components/jetstream_iroh/src/session.rs
@@ -20,7 +20,10 @@ use std::{
 
 use futures::{Sink, SinkExt, Stream, StreamExt};
 use iroh::{
-    endpoint::{Connection, ConnectionError, RecvStream, SendStream, VarInt},
+    endpoint::{
+        Connection, ConnectionError, RecvStream, SendDatagramError, SendStream,
+        VarInt,
+    },
     Endpoint,
 };
 use jetstream_rpc::{
@@ -41,7 +44,8 @@ const SESSION_CLOSED: u32 = 0;
 
 /// r[impl jetstream.session.lifetime]
 /// A connection error that means the session ended deliberately, rather
-/// than failed.
+/// than failed. Used everywhere a connection error crosses into
+/// `SessionError` — lanes and datagrams alike.
 ///
 /// `SessionError::Closed` is what a caller branches on to stop retrying,
 /// so mapping every `ConnectionError` to `Transport` told it that our
@@ -50,7 +54,7 @@ const SESSION_CLOSED: u32 = 0;
 /// the same, since `close` sends an application code. Everything else —
 /// a reset, an idle timeout, a protocol violation — really is a
 /// failure and keeps its own error.
-fn lane_error(err: ConnectionError) -> SessionError {
+fn connection_error(err: ConnectionError) -> SessionError {
     match err {
         ConnectionError::LocallyClosed
         | ConnectionError::ApplicationClosed(_) => SessionError::Closed,
@@ -214,8 +218,12 @@ where
     /// Every lane is its own QUIC stream, so one lane's stalled frame
     /// does not delay another's.
     async fn open_lane(&self) -> Result<Self::ClientLane, SessionError> {
-        let streams =
-            self.inner.connection.open_bi().await.map_err(lane_error)?;
+        let streams = self
+            .inner
+            .connection
+            .open_bi()
+            .await
+            .map_err(connection_error)?;
 
         Ok(match &self.inner.endpoint {
             Some(endpoint) => IrohTransport::new_owned(
@@ -236,7 +244,7 @@ where
             .connection
             .accept_bi()
             .await
-            .map_err(lane_error)?;
+            .map_err(connection_error)?;
 
         Ok(IrohServiceLane {
             send_stream: FramedWrite::new(send_stream, ServerCodec::new()),
@@ -281,10 +289,17 @@ where
         &self,
         bytes: Bytes,
     ) -> Result<(), SessionError> {
-        self.inner
-            .connection
-            .send_datagram(bytes)
-            .map_err(|err| SessionError::Transport(err.into_error()))
+        self.inner.connection.send_datagram(bytes).map_err(|err| {
+            // r[impl jetstream.session.lifetime]
+            // A send that failed because the session ended says so, the
+            // same as a lane open does. The other variants — no peer
+            // support, disabled locally, too large — are the transport
+            // reporting on the datagram itself.
+            match err {
+                SendDatagramError::ConnectionLost(err) => connection_error(err),
+                other => SessionError::Transport(other.into_error()),
+            }
+        })
     }
 
     async fn recv_datagram_bytes(&self) -> Result<Bytes, SessionError> {
@@ -292,7 +307,7 @@ where
             .connection
             .read_datagram()
             .await
-            .map_err(|err| SessionError::Transport(err.into_error()))
+            .map_err(connection_error)
     }
 }
 

--- a/components/jetstream_iroh/src/session.rs
+++ b/components/jetstream_iroh/src/session.rs
@@ -136,8 +136,20 @@ where
     type ServiceLane = IrohServiceLane<P>;
 
     /// r[impl jetstream.session.capabilities]
+    /// r[impl jetstream.session.capabilities.degradation]
+    /// The conformance row says iroh *can* carry datagrams. This
+    /// connection may not: a peer that never advertised DATAGRAM
+    /// support, or a transport configuration with them switched off,
+    /// leaves `max_datagram_size` empty and every send failing. A
+    /// capability is what this session has, not what its transport is
+    /// capable of in general — reporting the row unconditionally would
+    /// let `require(Capability::Datagrams)` succeed on a session that
+    /// cannot carry one.
     fn capabilities(&self) -> Capabilities {
-        Capabilities::iroh()
+        Capabilities {
+            datagrams: self.inner.connection.max_datagram_size().is_some(),
+            ..Capabilities::iroh()
+        }
     }
 
     /// r[impl jetstream.session.identity]

--- a/components/jetstream_iroh/src/session.rs
+++ b/components/jetstream_iroh/src/session.rs
@@ -11,7 +11,10 @@
 use std::{
     marker::PhantomData,
     pin::Pin,
-    sync::Arc,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
     task::{Context as TaskContext, Poll},
 };
 
@@ -47,6 +50,12 @@ const SESSION_CLOSED: u32 = 0;
 #[derive(Debug)]
 struct SessionInner {
     connection: Connection,
+    /// r[impl jetstream.session.capabilities]
+    /// Cleared by [`IrohSession::without_datagrams`]. Shared rather than
+    /// per-handle: whether this *connection* carries datagrams is a
+    /// property of the connection, so a clone taken before the override
+    /// must not go on claiming they work.
+    datagrams: AtomicBool,
     // Held for as long as the session is, for the same reason
     // `IrohTransport` holds them: iroh tears the connection down
     // ungracefully if the `Endpoint` is dropped while streams opened
@@ -71,10 +80,6 @@ impl Drop for SessionInner {
 /// connection closes when the last clone goes away.
 pub struct IrohSession<P: Protocol> {
     inner: Arc<SessionInner>,
-    /// r[impl jetstream.session.capabilities]
-    /// Cleared by [`IrohSession::without_datagrams`]; see there for why
-    /// the connection cannot answer this by itself.
-    datagrams: bool,
     _p: PhantomData<fn() -> P>,
 }
 
@@ -85,7 +90,6 @@ impl<P: Protocol> Clone for IrohSession<P> {
     fn clone(&self) -> Self {
         Self {
             inner: self.inner.clone(),
-            datagrams: self.datagrams,
             _p: PhantomData,
         }
     }
@@ -110,8 +114,8 @@ impl<P: Protocol> IrohSession<P> {
             inner: Arc::new(SessionInner {
                 connection,
                 endpoint: None,
+                datagrams: AtomicBool::new(true),
             }),
-            datagrams: true,
             _p: PhantomData,
         }
     }
@@ -122,8 +126,8 @@ impl<P: Protocol> IrohSession<P> {
             inner: Arc::new(SessionInner {
                 connection,
                 endpoint: Some(endpoint),
+                datagrams: AtomicBool::new(true),
             }),
-            datagrams: true,
             _p: PhantomData,
         }
     }
@@ -143,8 +147,13 @@ impl<P: Protocol> IrohSession<P> {
     /// switched off still sees a size, while every send fails and
     /// nothing can arrive. There is no way to read that back from the
     /// connection, so the caller that turned them off says so here.
-    pub fn without_datagrams(mut self) -> Self {
-        self.datagrams = false;
+    ///
+    /// The override is shared by every handle on this connection,
+    /// including clones taken before the call: a clone that went on
+    /// claiming datagrams work would recreate exactly the mismatch this
+    /// is here to prevent.
+    pub fn without_datagrams(self) -> Self {
+        self.inner.datagrams.store(false, Ordering::SeqCst);
         self
     }
 }
@@ -244,7 +253,7 @@ where
     P::Response: 'static,
 {
     fn max_datagram_size(&self) -> Option<u32> {
-        if !self.datagrams {
+        if !self.inner.datagrams.load(Ordering::SeqCst) {
             return None;
         }
         self.inner

--- a/components/jetstream_iroh/src/session.rs
+++ b/components/jetstream_iroh/src/session.rs
@@ -29,7 +29,7 @@ use iroh::{
 use jetstream_rpc::{
     context::{Context, Contextual, NodeId},
     server::ServerCodec,
-    session::{Capabilities, Datagrams, Session, SessionError},
+    session::{Capabilities, Capability, Datagrams, Session, SessionError},
     Error, Frame, IntoError, Protocol,
 };
 use tokio_util::{
@@ -179,6 +179,28 @@ impl<P: Protocol> IrohSession<P> {
         self.inner.datagrams.store(false, Ordering::SeqCst);
         self
     }
+
+    /// r[impl jetstream.session.capabilities.degradation]
+    /// Refuse datagram traffic on a session that reports no datagram
+    /// channel, so the raw methods agree with the capability instead of
+    /// the caller having to check it first.
+    ///
+    /// Receiving is why this exists. `read_datagram` on an endpoint
+    /// whose datagram receive buffer is switched off never yields, so
+    /// the caller parked until the connection closed — a capability
+    /// that is absent has to *fail*, not hang. Sending is here for the
+    /// same reason at less cost: quinn refuses it when the endpoint
+    /// really was configured without datagrams, but a caller that
+    /// called `without_datagrams` to opt out at this layer alone would
+    /// otherwise have sends succeed on a session reporting it has no
+    /// channel to send on.
+    fn no_datagrams(&self) -> Result<(), SessionError> {
+        if self.inner.datagrams.load(Ordering::SeqCst) {
+            Ok(())
+        } else {
+            Err(SessionError::Unsupported(Capability::Datagrams))
+        }
+    }
 }
 
 #[async_trait::async_trait]
@@ -289,6 +311,7 @@ where
         &self,
         bytes: Bytes,
     ) -> Result<(), SessionError> {
+        self.no_datagrams()?;
         self.inner.connection.send_datagram(bytes).map_err(|err| {
             // r[impl jetstream.session.lifetime]
             // A send that failed because the session ended says so, the
@@ -303,6 +326,7 @@ where
     }
 
     async fn recv_datagram_bytes(&self) -> Result<Bytes, SessionError> {
+        self.no_datagrams()?;
         self.inner
             .connection
             .read_datagram()

--- a/components/jetstream_iroh/src/session.rs
+++ b/components/jetstream_iroh/src/session.rs
@@ -186,10 +186,23 @@ where
 
         // r[impl jetstream.session.datagrams]
         // A datagram carries a complete frame or it is discarded; there
-        // is nothing to reassemble it from.
+        // is nothing to reassemble it from. Trailing bytes after the
+        // frame mean it is not a complete frame either — decoding would
+        // succeed on the prefix and hand back something the peer never
+        // sent.
         let mut reader = std::io::Cursor::new(datagram.as_ref());
-        Frame::<P::Response>::decode(&mut reader)
-            .map_err(|err| SessionError::Transport(Error::from(err)))
+        let frame = Frame::<P::Response>::decode(&mut reader)
+            .map_err(|err| SessionError::Transport(Error::from(err)))?;
+
+        let consumed = reader.position() as usize;
+        if consumed != datagram.len() {
+            return Err(SessionError::Transport(Error::new(format!(
+                "datagram has {} trailing bytes after the frame",
+                datagram.len() - consumed
+            ))));
+        }
+
+        Ok(frame)
     }
 }
 

--- a/components/jetstream_iroh/src/session.rs
+++ b/components/jetstream_iroh/src/session.rs
@@ -20,7 +20,7 @@ use std::{
 
 use futures::{Sink, SinkExt, Stream, StreamExt};
 use iroh::{
-    endpoint::{Connection, RecvStream, SendStream, VarInt},
+    endpoint::{Connection, ConnectionError, RecvStream, SendStream, VarInt},
     Endpoint,
 };
 use jetstream_rpc::{
@@ -38,6 +38,25 @@ use crate::IrohTransport;
 
 /// The code an iroh connection is closed with when its session closes.
 const SESSION_CLOSED: u32 = 0;
+
+/// r[impl jetstream.session.lifetime]
+/// A connection error that means the session ended deliberately, rather
+/// than failed.
+///
+/// `SessionError::Closed` is what a caller branches on to stop retrying,
+/// so mapping every `ConnectionError` to `Transport` told it that our
+/// own `close` — and a peer's — was a transport fault. `LocallyClosed`
+/// is this end calling `close`; `ApplicationClosed` is the far end doing
+/// the same, since `close` sends an application code. Everything else —
+/// a reset, an idle timeout, a protocol violation — really is a
+/// failure and keeps its own error.
+fn lane_error(err: ConnectionError) -> SessionError {
+    match err {
+        ConnectionError::LocallyClosed
+        | ConnectionError::ApplicationClosed(_) => SessionError::Closed,
+        other => SessionError::Transport(other.into_error()),
+    }
+}
 
 /// What every handle on one session shares.
 ///
@@ -195,12 +214,8 @@ where
     /// Every lane is its own QUIC stream, so one lane's stalled frame
     /// does not delay another's.
     async fn open_lane(&self) -> Result<Self::ClientLane, SessionError> {
-        let streams = self
-            .inner
-            .connection
-            .open_bi()
-            .await
-            .map_err(|err| SessionError::Transport(err.into_error()))?;
+        let streams =
+            self.inner.connection.open_bi().await.map_err(lane_error)?;
 
         Ok(match &self.inner.endpoint {
             Some(endpoint) => IrohTransport::new_owned(
@@ -221,7 +236,7 @@ where
             .connection
             .accept_bi()
             .await
-            .map_err(|err| SessionError::Transport(err.into_error()))?;
+            .map_err(lane_error)?;
 
         Ok(IrohServiceLane {
             send_stream: FramedWrite::new(send_stream, ServerCodec::new()),

--- a/components/jetstream_iroh/src/session.rs
+++ b/components/jetstream_iroh/src/session.rs
@@ -71,6 +71,10 @@ impl Drop for SessionInner {
 /// connection closes when the last clone goes away.
 pub struct IrohSession<P: Protocol> {
     inner: Arc<SessionInner>,
+    /// r[impl jetstream.session.capabilities]
+    /// Cleared by [`IrohSession::without_datagrams`]; see there for why
+    /// the connection cannot answer this by itself.
+    datagrams: bool,
     _p: PhantomData<fn() -> P>,
 }
 
@@ -81,6 +85,7 @@ impl<P: Protocol> Clone for IrohSession<P> {
     fn clone(&self) -> Self {
         Self {
             inner: self.inner.clone(),
+            datagrams: self.datagrams,
             _p: PhantomData,
         }
     }
@@ -106,6 +111,7 @@ impl<P: Protocol> IrohSession<P> {
                 connection,
                 endpoint: None,
             }),
+            datagrams: true,
             _p: PhantomData,
         }
     }
@@ -117,6 +123,7 @@ impl<P: Protocol> IrohSession<P> {
                 connection,
                 endpoint: Some(endpoint),
             }),
+            datagrams: true,
             _p: PhantomData,
         }
     }
@@ -124,6 +131,21 @@ impl<P: Protocol> IrohSession<P> {
     /// The underlying connection.
     pub fn connection(&self) -> &Connection {
         &self.inner.connection
+    }
+
+    /// Report this session as carrying no datagrams.
+    ///
+    /// r[impl jetstream.session.capabilities]
+    /// [`Session::capabilities`] derives datagram support from
+    /// `max_datagram_size`, which underneath reads the *peer's*
+    /// advertised limit and the path MTU. It is silent about this
+    /// endpoint's own configuration: an endpoint built with datagrams
+    /// switched off still sees a size, while every send fails and
+    /// nothing can arrive. There is no way to read that back from the
+    /// connection, so the caller that turned them off says so here.
+    pub fn without_datagrams(mut self) -> Self {
+        self.datagrams = false;
+        self
     }
 }
 
@@ -147,7 +169,8 @@ where
     /// cannot carry one.
     fn capabilities(&self) -> Capabilities {
         Capabilities {
-            datagrams: self.inner.connection.max_datagram_size().is_some(),
+            datagrams: <Self as Datagrams<P>>::max_datagram_size(self)
+                .is_some(),
             ..Capabilities::iroh()
         }
     }
@@ -221,6 +244,9 @@ where
     P::Response: 'static,
 {
     fn max_datagram_size(&self) -> Option<u32> {
+        if !self.datagrams {
+            return None;
+        }
         self.inner
             .connection
             .max_datagram_size()

--- a/components/jetstream_iroh/src/session.rs
+++ b/components/jetstream_iroh/src/session.rs
@@ -1,0 +1,269 @@
+//! The iroh connection as a JetStream session.
+//!
+//! r[impl jetstream.session.conformance.iroh]
+//! An iroh `Connection` carries as many streams as the peers care to
+//! open, and its peer identity is a public key that is also the address.
+//! Opening one bidirectional stream at connect time and holding on to
+//! nothing else throws both away. [`IrohSession`] keeps the connection
+//! and hands out a lane per `open_bi`, so a caller decides how many
+//! lanes it wants and when.
+
+use std::{
+    marker::PhantomData,
+    pin::Pin,
+    task::{Context as TaskContext, Poll},
+};
+
+use futures::{Sink, SinkExt, Stream, StreamExt};
+use iroh::{
+    endpoint::{Connection, RecvStream, SendStream, VarInt},
+    Endpoint,
+};
+use jetstream_rpc::{
+    context::{Context, Contextual, NodeId},
+    server::ServerCodec,
+    session::{
+        check_datagram_size, Capabilities, Datagrams, Session, SessionError,
+    },
+    Error, Frame, IntoError, Protocol,
+};
+use jetstream_wireformat::WireFormat;
+use tokio_util::{
+    bytes::Bytes,
+    codec::{FramedRead, FramedWrite},
+};
+
+use crate::IrohTransport;
+
+/// The code an iroh connection is closed with when its session closes.
+const SESSION_CLOSED: u32 = 0;
+
+/// A JetStream session over an iroh connection.
+///
+/// Cloning the session is cheap and every clone addresses the same
+/// connection, so lanes can be opened from several tasks at once.
+#[derive(Debug, Clone)]
+pub struct IrohSession<P: Protocol> {
+    connection: Connection,
+    // Held for as long as the session is, for the same reason
+    // `IrohTransport` holds them: iroh tears the connection down
+    // ungracefully if the `Endpoint` is dropped while streams opened
+    // from it are still in use.
+    endpoint: Option<Endpoint>,
+    _p: PhantomData<fn() -> P>,
+}
+
+impl<P: Protocol> IrohSession<P> {
+    /// Wrap a connection whose endpoint the caller keeps alive.
+    pub fn new(connection: Connection) -> Self {
+        Self {
+            connection,
+            endpoint: None,
+            _p: PhantomData,
+        }
+    }
+
+    /// Wrap a connection and keep `endpoint` alive alongside it.
+    pub fn new_owned(connection: Connection, endpoint: Endpoint) -> Self {
+        Self {
+            connection,
+            endpoint: Some(endpoint),
+            _p: PhantomData,
+        }
+    }
+
+    /// The underlying connection.
+    pub fn connection(&self) -> &Connection {
+        &self.connection
+    }
+}
+
+#[async_trait::async_trait]
+impl<P> Session<P> for IrohSession<P>
+where
+    P: Protocol<Error = Error> + 'static,
+{
+    type ClientLane = IrohTransport<P>;
+    type ServiceLane = IrohServiceLane<P>;
+
+    /// r[impl jetstream.session.capabilities]
+    fn capabilities(&self) -> Capabilities {
+        Capabilities::iroh()
+    }
+
+    /// r[impl jetstream.session.identity]
+    /// iroh establishes the peer's public key during the handshake, so
+    /// the identity is available without the peer asserting anything.
+    fn context(&self) -> Context {
+        Context::from(NodeId::from(self.connection.remote_id()))
+    }
+
+    /// r[impl jetstream.lane.independence]
+    /// Every lane is its own QUIC stream, so one lane's stalled frame
+    /// does not delay another's.
+    async fn open_lane(&self) -> Result<Self::ClientLane, SessionError> {
+        let streams = self
+            .connection
+            .open_bi()
+            .await
+            .map_err(|err| SessionError::Transport(err.into_error()))?;
+
+        Ok(match &self.endpoint {
+            Some(endpoint) => IrohTransport::new_owned(
+                streams,
+                self.connection.clone(),
+                endpoint.clone(),
+            ),
+            None => IrohTransport::from(streams),
+        })
+    }
+
+    /// r[impl jetstream.session.symmetric]
+    /// Either peer may open a lane on an iroh connection, so a client
+    /// that accepts is not doing anything unusual.
+    async fn accept_lane(&self) -> Result<Self::ServiceLane, SessionError> {
+        let (send_stream, recv_stream) = self
+            .connection
+            .accept_bi()
+            .await
+            .map_err(|err| SessionError::Transport(err.into_error()))?;
+
+        Ok(IrohServiceLane {
+            send_stream: FramedWrite::new(send_stream, ServerCodec::new()),
+            recv_stream: FramedRead::new(recv_stream, ServerCodec::new()),
+            context: <Self as Session<P>>::context(self),
+        })
+    }
+
+    /// r[impl jetstream.session.lifetime]
+    /// Closing the connection resets every stream opened on it, so lanes
+    /// terminate with the session rather than outliving it, and calls in
+    /// flight on them fail rather than hang.
+    async fn close(&self) {
+        self.connection
+            .close(VarInt::from_u32(SESSION_CLOSED), b"session closed");
+    }
+}
+
+/// r[impl jetstream.session.datagrams]
+/// iroh carries QUIC datagrams, which belong to the connection and not
+/// to any stream on it.
+#[async_trait::async_trait]
+impl<P> Datagrams<P> for IrohSession<P>
+where
+    P: Protocol<Error = Error> + 'static,
+{
+    fn max_datagram_size(&self) -> Option<u32> {
+        self.connection
+            .max_datagram_size()
+            .map(|size| size.min(u32::MAX as usize) as u32)
+    }
+
+    async fn send_datagram(
+        &self,
+        frame: Frame<P::Request>,
+    ) -> Result<(), SessionError> {
+        // r[impl jetstream.session.datagrams]
+        // Rejected here rather than fragmented.
+        check_datagram_size(&frame, self.max_datagram_size())?;
+
+        let mut buf = Vec::with_capacity(frame.byte_size() as usize);
+        frame
+            .encode(&mut buf)
+            .map_err(|err| SessionError::Transport(Error::from(err)))?;
+
+        self.connection
+            .send_datagram(Bytes::from(buf))
+            .map_err(|err| SessionError::Transport(err.into_error()))
+    }
+
+    async fn recv_datagram(&self) -> Result<Frame<P::Response>, SessionError> {
+        let datagram = self
+            .connection
+            .read_datagram()
+            .await
+            .map_err(|err| SessionError::Transport(err.into_error()))?;
+
+        // r[impl jetstream.session.datagrams]
+        // A datagram carries a complete frame or it is discarded; there
+        // is nothing to reassemble it from.
+        let mut reader = std::io::Cursor::new(datagram.as_ref());
+        Frame::<P::Response>::decode(&mut reader)
+            .map_err(|err| SessionError::Transport(Error::from(err)))
+    }
+}
+
+/// The callee's end of a lane the peer opened.
+///
+/// r[impl jetstream.lane.definition]
+/// One iroh bidirectional stream, framed, satisfying
+/// `ServiceTransport<P>`.
+pub struct IrohServiceLane<P: Protocol> {
+    send_stream: FramedWrite<SendStream, ServerCodec<P>>,
+    recv_stream: FramedRead<RecvStream, ServerCodec<P>>,
+    context: Context,
+}
+
+impl<P: Protocol> IrohServiceLane<P> {
+    /// Build a lane from a stream pair the caller accepted itself.
+    pub fn new(
+        send_stream: SendStream,
+        recv_stream: RecvStream,
+        context: Context,
+    ) -> Self {
+        Self {
+            send_stream: FramedWrite::new(send_stream, ServerCodec::new()),
+            recv_stream: FramedRead::new(recv_stream, ServerCodec::new()),
+            context,
+        }
+    }
+}
+
+impl<P: Protocol> Sink<Frame<P::Response>> for IrohServiceLane<P> {
+    type Error = Error;
+
+    fn poll_ready(
+        self: Pin<&mut Self>,
+        cx: &mut TaskContext<'_>,
+    ) -> Poll<Result<(), Self::Error>> {
+        self.get_mut().send_stream.poll_ready_unpin(cx)
+    }
+
+    fn start_send(
+        self: Pin<&mut Self>,
+        item: Frame<P::Response>,
+    ) -> Result<(), Self::Error> {
+        self.get_mut().send_stream.start_send_unpin(item)
+    }
+
+    fn poll_flush(
+        self: Pin<&mut Self>,
+        cx: &mut TaskContext<'_>,
+    ) -> Poll<Result<(), Self::Error>> {
+        self.get_mut().send_stream.poll_flush_unpin(cx)
+    }
+
+    fn poll_close(
+        self: Pin<&mut Self>,
+        cx: &mut TaskContext<'_>,
+    ) -> Poll<Result<(), Self::Error>> {
+        self.get_mut().send_stream.poll_close_unpin(cx)
+    }
+}
+
+impl<P: Protocol> Stream for IrohServiceLane<P> {
+    type Item = Result<Frame<P::Request>, Error>;
+
+    fn poll_next(
+        self: Pin<&mut Self>,
+        cx: &mut TaskContext<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        self.get_mut().recv_stream.poll_next_unpin(cx)
+    }
+}
+
+impl<P: Protocol> Contextual for IrohServiceLane<P> {
+    fn context(&self) -> Context {
+        self.context.clone()
+    }
+}

--- a/components/jetstream_rpc/Cargo.toml
+++ b/components/jetstream_rpc/Cargo.toml
@@ -56,6 +56,12 @@ tokio = { version = "1.47.1", features = ["net"] }
 bytes = "1.11.1"
 anyhow = "1.0.102"
 proptest = "1.11.0"
+tokio = { version = "1.47.1", features = [
+  "macros",
+  "rt",
+  "rt-multi-thread",
+  "time",
+] }
 
 
 [features]

--- a/components/jetstream_rpc/src/lib.rs
+++ b/components/jetstream_rpc/src/lib.rs
@@ -20,6 +20,7 @@ pub mod framer;
 mod mux;
 mod router;
 pub mod server;
+pub mod session;
 mod tag;
 mod version;
 pub use any_server::AnyServer;

--- a/components/jetstream_rpc/src/session/capabilities.rs
+++ b/components/jetstream_rpc/src/session/capabilities.rs
@@ -1,0 +1,201 @@
+//! Session capabilities.
+//!
+//! r[impl jetstream.session.capabilities]
+//! Capabilities are reported by the session, not inferred from the
+//! concrete transport type and not reduced to a lowest common
+//! denominator, so that a caller can pick a multiplexing strategy
+//! without knowing which transport it is holding.
+
+use std::fmt::{self, Display};
+
+use crate::session::error::SessionError;
+
+/// How many lanes a session can carry.
+///
+/// r[impl jetstream.session.single-lane]
+/// A byte-stream transport reports [`LaneSupport::One`]: its first lane
+/// open succeeds and every later one fails with
+/// [`SessionError::LaneLimitReached`] rather than blocking or silently
+/// sharing the lane that is already open.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum LaneSupport {
+    /// Exactly one lane for the lifetime of the session.
+    One,
+    /// Any number of independent lanes.
+    Many,
+}
+
+impl LaneSupport {
+    /// Whether more than one lane can be open at a time.
+    pub fn is_many(&self) -> bool {
+        matches!(self, LaneSupport::Many)
+    }
+}
+
+impl Display for LaneSupport {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            LaneSupport::One => write!(f, "one"),
+            LaneSupport::Many => write!(f, "many"),
+        }
+    }
+}
+
+/// The peer identity model a session's transport establishes.
+///
+/// r[impl jetstream.session.identity]
+/// The identity *value* travels in [`crate::context::Context`]; this is
+/// the model, which is what a caller has to branch on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum IdentityKind {
+    /// No transport-level peer authentication: unix sockets, plain TCP,
+    /// in-process.
+    None,
+    /// A TLS peer certificate: QUIC and WebTransport.
+    Certificate,
+    /// A public key established by the transport itself: iroh.
+    Key,
+}
+
+impl IdentityKind {
+    /// r[impl jetstream.session.identity.addressing]
+    /// Whether a caller must supply a network address to reach a peer.
+    /// Under [`IdentityKind::Key`] the identity is the address, so a
+    /// caller MUST NOT be required to carry placement information
+    /// alongside it.
+    pub fn requires_address(&self) -> bool {
+        !matches!(self, IdentityKind::Key)
+    }
+}
+
+impl Display for IdentityKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            IdentityKind::None => write!(f, "none"),
+            IdentityKind::Certificate => write!(f, "certificate"),
+            IdentityKind::Key => write!(f, "key"),
+        }
+    }
+}
+
+/// A single capability, named so that a session can say what it is
+/// missing when code asks for something it does not have.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Capability {
+    /// More than one lane per session.
+    ManyLanes,
+    /// An unordered, unreliable datagram channel.
+    Datagrams,
+    /// Survival across a change of network path.
+    Migration,
+    /// Dialling a peer by identity alone, with no address.
+    KeyAddressing,
+}
+
+impl Display for Capability {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Capability::ManyLanes => write!(f, "many lanes"),
+            Capability::Datagrams => write!(f, "datagrams"),
+            Capability::Migration => write!(f, "migration"),
+            Capability::KeyAddressing => write!(f, "key addressing"),
+        }
+    }
+}
+
+/// What a session can do.
+///
+/// The constructors mirror the conformance table in the sessions and
+/// lanes specification, so that a transport declares its row rather than
+/// assembling one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Capabilities {
+    /// Whether the session can carry more than one lane.
+    pub lanes: LaneSupport,
+    /// Whether the session has an unordered datagram channel.
+    pub datagrams: bool,
+    /// The peer identity model.
+    pub identity: IdentityKind,
+    /// Whether the session survives a change of network path.
+    pub migration: bool,
+}
+
+impl Capabilities {
+    /// r[impl jetstream.session.conformance.iroh]
+    /// iroh: many lanes, datagrams, key identity, migrates.
+    pub const fn iroh() -> Self {
+        Self {
+            lanes: LaneSupport::Many,
+            datagrams: true,
+            identity: IdentityKind::Key,
+            migration: true,
+        }
+    }
+
+    /// QUIC: many lanes, datagrams, certificate identity, migrates.
+    pub const fn quic() -> Self {
+        Self {
+            lanes: LaneSupport::Many,
+            datagrams: true,
+            identity: IdentityKind::Certificate,
+            migration: true,
+        }
+    }
+
+    /// r[impl jetstream.session.conformance.webtransport]
+    /// WebTransport over HTTP/3: many lanes, datagrams, certificate
+    /// identity, migrates.
+    pub const fn webtransport() -> Self {
+        Self {
+            lanes: LaneSupport::Many,
+            datagrams: true,
+            identity: IdentityKind::Certificate,
+            migration: true,
+        }
+    }
+
+    /// r[impl jetstream.session.conformance.single-stream]
+    /// TCP, TLS, unix sockets and stdio: one lane, nothing else.
+    pub const fn byte_stream() -> Self {
+        Self {
+            lanes: LaneSupport::One,
+            datagrams: false,
+            identity: IdentityKind::None,
+            migration: false,
+        }
+    }
+
+    /// r[impl jetstream.session.local]
+    /// In-process: many lanes, no datagrams, no identity. Migration is
+    /// not meaningful, so it is reported as absent.
+    pub const fn in_process() -> Self {
+        Self {
+            lanes: LaneSupport::Many,
+            datagrams: false,
+            identity: IdentityKind::None,
+            migration: false,
+        }
+    }
+
+    /// Whether this session has `capability`.
+    pub fn supports(&self, capability: Capability) -> bool {
+        match capability {
+            Capability::ManyLanes => self.lanes.is_many(),
+            Capability::Datagrams => self.datagrams,
+            Capability::Migration => self.migration,
+            Capability::KeyAddressing => !self.identity.requires_address(),
+        }
+    }
+
+    /// r[impl jetstream.session.capabilities.degradation]
+    /// Fail explicitly for a capability the session does not have, so
+    /// that the alternative — emulating it silently — is never the easy
+    /// path.
+    pub fn require(&self, capability: Capability) -> Result<(), SessionError> {
+        if self.supports(capability) {
+            Ok(())
+        } else {
+            Err(SessionError::Unsupported(capability))
+        }
+    }
+}

--- a/components/jetstream_rpc/src/session/error.rs
+++ b/components/jetstream_rpc/src/session/error.rs
@@ -7,6 +7,13 @@ use crate::{session::capabilities::Capability, Error};
 /// Every variant carries a stable code, reachable both from
 /// [`SessionError::code`] and from [`Error::code`] once converted, so
 /// that callers can inspect the reason instead of matching on a message.
+///
+/// [`SessionError::Transport`] is the one variant whose converted code
+/// may differ: it carries an error the transport produced, and that
+/// error's own code is more specific than a session-level one, so it is
+/// kept when present. The session code is stamped only when the inner
+/// error carries none, which is why a converted transport error always
+/// has *a* code but not always this one.
 #[derive(Debug, Clone, thiserror::Error)]
 pub enum SessionError {
     /// r[impl jetstream.session.single-lane]
@@ -57,6 +64,10 @@ pub enum SessionError {
 }
 
 impl SessionError {
+    /// The code stamped on a transport error that carries none of its
+    /// own.
+    pub const TRANSPORT_CODE: &'static str = "jetstream::session::transport";
+
     /// The stable code for this error.
     pub fn code(&self) -> &'static str {
         match self {
@@ -75,7 +86,7 @@ impl SessionError {
             SessionError::DatagramTooLarge { .. } => {
                 "jetstream::session::datagram_too_large"
             }
-            SessionError::Transport(_) => "jetstream::session::transport",
+            SessionError::Transport(_) => Self::TRANSPORT_CODE,
         }
     }
 }
@@ -83,7 +94,18 @@ impl SessionError {
 impl From<SessionError> for Error {
     fn from(err: SessionError) -> Self {
         match err {
-            SessionError::Transport(inner) => inner,
+            // Keep the transport's own code, span trace and backtrace:
+            // "the QUIC connection was reset" tells a caller more than
+            // "a session transport failed". Stamp the session code only
+            // when there is nothing to lose by it, so that a converted
+            // transport error is never left uninspectable.
+            SessionError::Transport(inner) => {
+                if inner.code().is_some() {
+                    inner
+                } else {
+                    inner.set_code(SessionError::TRANSPORT_CODE)
+                }
+            }
             other => {
                 let code = other.code();
                 Error::with_code(other.to_string(), code)

--- a/components/jetstream_rpc/src/session/error.rs
+++ b/components/jetstream_rpc/src/session/error.rs
@@ -1,0 +1,99 @@
+//! Errors a session can report.
+
+use crate::{session::capabilities::Capability, Error};
+
+/// Something a session was asked to do and could not.
+///
+/// Every variant carries a stable code, reachable both from
+/// [`SessionError::code`] and from [`Error::code`] once converted, so
+/// that callers can inspect the reason instead of matching on a message.
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum SessionError {
+    /// r[impl jetstream.session.single-lane]
+    /// The session carries one lane and that lane is already open.
+    #[error("session supports one lane and it is already open")]
+    LaneLimitReached,
+
+    /// The session cannot accept peer-opened lanes. A client on a
+    /// byte-stream transport is the usual case.
+    #[error("session does not accept peer-opened lanes")]
+    AcceptUnsupported,
+
+    /// The session cannot open lanes. A server holding one accepted
+    /// byte stream is the usual case.
+    #[error("session does not open lanes")]
+    OpenUnsupported,
+
+    /// r[impl jetstream.session.lifetime]
+    /// The session is closed. Opening, accepting and any in-flight call
+    /// on one of its lanes fails with this rather than hanging.
+    #[error("session is closed")]
+    Closed,
+
+    /// The lane is closed while its session is not: the peer end was
+    /// dropped.
+    #[error("lane is closed")]
+    LaneClosed,
+
+    /// r[impl jetstream.session.capabilities.degradation]
+    /// Code asked for a capability this session does not report.
+    #[error("session does not support {0}")]
+    Unsupported(Capability),
+
+    /// r[impl jetstream.session.datagrams]
+    /// A datagram larger than the path limit. Rejected at the send site
+    /// rather than fragmented.
+    #[error("datagram of {size} bytes exceeds the {limit} byte limit")]
+    DatagramTooLarge {
+        /// Encoded size of the frame that was offered.
+        size: u32,
+        /// The path's datagram limit.
+        limit: u32,
+    },
+
+    /// The underlying transport failed.
+    #[error("transport error: {0}")]
+    Transport(#[source] Error),
+}
+
+impl SessionError {
+    /// The stable code for this error.
+    pub fn code(&self) -> &'static str {
+        match self {
+            SessionError::LaneLimitReached => {
+                "jetstream::session::lane_limit_reached"
+            }
+            SessionError::AcceptUnsupported => {
+                "jetstream::session::accept_unsupported"
+            }
+            SessionError::OpenUnsupported => {
+                "jetstream::session::open_unsupported"
+            }
+            SessionError::Closed => "jetstream::session::closed",
+            SessionError::LaneClosed => "jetstream::session::lane_closed",
+            SessionError::Unsupported(_) => "jetstream::session::unsupported",
+            SessionError::DatagramTooLarge { .. } => {
+                "jetstream::session::datagram_too_large"
+            }
+            SessionError::Transport(_) => "jetstream::session::transport",
+        }
+    }
+}
+
+impl From<SessionError> for Error {
+    fn from(err: SessionError) -> Self {
+        match err {
+            SessionError::Transport(inner) => inner,
+            other => {
+                let code = other.code();
+                Error::with_code(other.to_string(), code)
+            }
+        }
+    }
+}
+
+impl From<Error> for SessionError {
+    fn from(err: Error) -> Self {
+        SessionError::Transport(err)
+    }
+}

--- a/components/jetstream_rpc/src/session/lifetime.rs
+++ b/components/jetstream_rpc/src/session/lifetime.rs
@@ -190,7 +190,16 @@ where
         self: Pin<&mut Self>,
         cx: &mut TaskContext<'_>,
     ) -> Poll<Result<(), Self::Error>> {
-        Pin::new(&mut self.get_mut().lane).poll_close(cx)
+        let this = self.get_mut();
+        // r[impl jetstream.session.lifetime]
+        // A close already parked on the wrapped lane is not reachable
+        // from the session, which handed the lane out. Without this the
+        // one operation that cannot be abandoned — closing — is also
+        // the one that would hang forever behind a stuck transport.
+        if this.lifetime.poll_closed(cx) {
+            return Poll::Ready(Err(SessionError::Closed.into()));
+        }
+        Pin::new(&mut this.lane).poll_close(cx)
     }
 }
 

--- a/components/jetstream_rpc/src/session/lifetime.rs
+++ b/components/jetstream_rpc/src/session/lifetime.rs
@@ -1,0 +1,158 @@
+//! Session-scoped lane lifetime.
+//!
+//! r[impl jetstream.session.lifetime]
+//! A lane must not outlive its session. Each lane holds the receiving
+//! half of a token its session owns; when the session closes it drops
+//! the sending halves, and every lane observes that on its next poll —
+//! its stream reports the closure and then ends, and its sink refuses
+//! further writes, so a call in flight fails rather than hanging.
+
+use std::{
+    pin::Pin,
+    task::{Context as TaskContext, Poll},
+};
+
+use futures::{channel::oneshot, Future, Sink, Stream};
+
+use crate::{
+    context::{Context, Contextual},
+    session::error::SessionError,
+    Error,
+};
+
+/// One lane's share of its session's lifetime.
+pub(crate) struct LaneLifetime {
+    token: Option<oneshot::Receiver<()>>,
+    /// Whether the closure has already been reported to the reader, so
+    /// that a closed lane reports once and then ends.
+    pub(crate) reported: bool,
+}
+
+impl LaneLifetime {
+    pub(crate) fn new(token: oneshot::Receiver<()>) -> Self {
+        Self {
+            token: Some(token),
+            reported: false,
+        }
+    }
+
+    /// Whether the session has closed, registering `cx` if it has not.
+    pub(crate) fn poll_closed(&mut self, cx: &mut TaskContext<'_>) -> bool {
+        let Some(token) = self.token.as_mut() else {
+            return true;
+        };
+        match Pin::new(token).poll(cx) {
+            Poll::Ready(_) => {
+                self.token = None;
+                true
+            }
+            Poll::Pending => false,
+        }
+    }
+}
+
+/// A lane that terminates when its session closes.
+///
+/// r[impl jetstream.session.lifetime]
+/// Wraps a lane the session handed to a caller. Once the caller owns the
+/// lane the session can no longer reach inside it, so the lane observes
+/// the session's closure itself rather than the session reaching back.
+///
+/// The `Sink` and `Stream` impls are generic over what the wrapped lane
+/// carries, so one guard serves both directions: the caller's end
+/// (requests out, responses in) and the callee's (responses out,
+/// requests in).
+pub struct LaneGuard<L> {
+    lane: L,
+    lifetime: LaneLifetime,
+}
+
+impl<L> LaneGuard<L> {
+    pub(crate) fn new(lane: L, token: oneshot::Receiver<()>) -> Self {
+        Self {
+            lane,
+            lifetime: LaneLifetime::new(token),
+        }
+    }
+
+    /// The wrapped lane.
+    pub fn get_ref(&self) -> &L {
+        &self.lane
+    }
+}
+
+impl<L: std::fmt::Debug> std::fmt::Debug for LaneGuard<L> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LaneGuard")
+            .field("lane", &self.lane)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<L, Item> Sink<Item> for LaneGuard<L>
+where
+    L: Sink<Item, Error = Error> + Unpin,
+{
+    type Error = Error;
+
+    fn poll_ready(
+        self: Pin<&mut Self>,
+        cx: &mut TaskContext<'_>,
+    ) -> Poll<Result<(), Self::Error>> {
+        let this = self.get_mut();
+        if this.lifetime.poll_closed(cx) {
+            return Poll::Ready(Err(SessionError::Closed.into()));
+        }
+        Pin::new(&mut this.lane).poll_ready(cx)
+    }
+
+    fn start_send(self: Pin<&mut Self>, item: Item) -> Result<(), Self::Error> {
+        Pin::new(&mut self.get_mut().lane).start_send(item)
+    }
+
+    fn poll_flush(
+        self: Pin<&mut Self>,
+        cx: &mut TaskContext<'_>,
+    ) -> Poll<Result<(), Self::Error>> {
+        let this = self.get_mut();
+        if this.lifetime.poll_closed(cx) {
+            return Poll::Ready(Err(SessionError::Closed.into()));
+        }
+        Pin::new(&mut this.lane).poll_flush(cx)
+    }
+
+    fn poll_close(
+        self: Pin<&mut Self>,
+        cx: &mut TaskContext<'_>,
+    ) -> Poll<Result<(), Self::Error>> {
+        Pin::new(&mut self.get_mut().lane).poll_close(cx)
+    }
+}
+
+impl<L, T> Stream for LaneGuard<L>
+where
+    L: Stream<Item = Result<T, Error>> + Unpin,
+{
+    type Item = Result<T, Error>;
+
+    fn poll_next(
+        self: Pin<&mut Self>,
+        cx: &mut TaskContext<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+        if this.lifetime.poll_closed(cx) {
+            if this.lifetime.reported {
+                return Poll::Ready(None);
+            }
+            this.lifetime.reported = true;
+            return Poll::Ready(Some(Err(SessionError::Closed.into())));
+        }
+        Pin::new(&mut this.lane).poll_next(cx)
+    }
+}
+
+impl<L: Contextual> Contextual for LaneGuard<L> {
+    fn context(&self) -> Context {
+        self.lane.context()
+    }
+}

--- a/components/jetstream_rpc/src/session/lifetime.rs
+++ b/components/jetstream_rpc/src/session/lifetime.rs
@@ -1,18 +1,33 @@
 //! Session-scoped lane lifetime.
 //!
 //! r[impl jetstream.session.lifetime]
-//! A lane must not outlive its session. Each lane holds the receiving
-//! half of a token its session owns; when the session closes it drops
-//! the sending halves, and every lane observes that on its next poll —
-//! its stream reports the closure and then ends, and its sink refuses
-//! further writes, so a call in flight fails rather than hanging.
+//! A lane must not outlive its session. Each session owns a
+//! [`CancellationToken`] and hands every lane a child of it; closing the
+//! session cancels the parent, and every lane and every handle derived
+//! from one observes that. A lane's stream reports the closure and then
+//! ends, and its sink refuses further writes, so a call in flight fails
+//! rather than hanging.
+//!
+//! A cancellation token rather than a one-shot channel per lane, for
+//! three reasons: it is cloneable, so handles other than the lane itself
+//! — an [`crate::session::local::OrderedSender`], say — can observe the
+//! same closure; a child taken from an already-cancelled parent is born
+//! cancelled, which closes the race where a lane is handed out
+//! concurrently with `close`; and a dropped child deregisters itself, so
+//! a session that opens many short-lived lanes does not accumulate one
+//! entry per lane it has ever opened.
 
 use std::{
     pin::Pin,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
     task::{Context as TaskContext, Poll},
 };
 
-use futures::{channel::oneshot, Future, Sink, Stream};
+use futures::{Future, Sink, Stream};
+use tokio_util::sync::{CancellationToken, WaitForCancellationFutureOwned};
 
 use crate::{
     context::{Context, Contextual},
@@ -22,32 +37,46 @@ use crate::{
 
 /// One lane's share of its session's lifetime.
 pub(crate) struct LaneLifetime {
-    token: Option<oneshot::Receiver<()>>,
+    token: CancellationToken,
+    /// Built on first poll, so that a lane which is never polled costs
+    /// nothing.
+    waiter: Option<Pin<Box<WaitForCancellationFutureOwned>>>,
     /// Whether the closure has already been reported to the reader, so
     /// that a closed lane reports once and then ends.
     pub(crate) reported: bool,
+    live: Arc<AtomicUsize>,
 }
 
 impl LaneLifetime {
-    pub(crate) fn new(token: oneshot::Receiver<()>) -> Self {
+    pub(crate) fn new(
+        token: CancellationToken,
+        live: Arc<AtomicUsize>,
+    ) -> Self {
+        live.fetch_add(1, Ordering::SeqCst);
         Self {
-            token: Some(token),
+            token,
+            waiter: None,
             reported: false,
+            live,
         }
     }
 
     /// Whether the session has closed, registering `cx` if it has not.
     pub(crate) fn poll_closed(&mut self, cx: &mut TaskContext<'_>) -> bool {
-        let Some(token) = self.token.as_mut() else {
+        if self.token.is_cancelled() {
             return true;
-        };
-        match Pin::new(token).poll(cx) {
-            Poll::Ready(_) => {
-                self.token = None;
-                true
-            }
-            Poll::Pending => false,
         }
+        if self.waiter.is_none() {
+            self.waiter = Some(Box::pin(self.token.clone().cancelled_owned()));
+        }
+        let waiter = self.waiter.as_mut().expect("waiter was just constructed");
+        matches!(waiter.as_mut().poll(cx), Poll::Ready(()))
+    }
+}
+
+impl Drop for LaneLifetime {
+    fn drop(&mut self) {
+        self.live.fetch_sub(1, Ordering::SeqCst);
     }
 }
 
@@ -65,13 +94,34 @@ impl LaneLifetime {
 pub struct LaneGuard<L> {
     lane: L,
     lifetime: LaneLifetime,
+    /// r[impl jetstream.session.identity]
+    /// The identity the *session* established, where that is more than
+    /// the lane itself knows — a TLS adapter authenticates the peer
+    /// during a handshake the framed byte stream underneath never sees.
+    /// `None` means the lane's own context is the whole story.
+    context: Option<Context>,
 }
 
 impl<L> LaneGuard<L> {
-    pub(crate) fn new(lane: L, token: oneshot::Receiver<()>) -> Self {
+    pub(crate) fn new(lane: L, lifetime: LaneLifetime) -> Self {
         Self {
             lane,
-            lifetime: LaneLifetime::new(token),
+            lifetime,
+            context: None,
+        }
+    }
+
+    /// A guard that reports the session's identity rather than the
+    /// wrapped lane's.
+    pub(crate) fn with_context(
+        lane: L,
+        lifetime: LaneLifetime,
+        context: Option<Context>,
+    ) -> Self {
+        Self {
+            lane,
+            lifetime,
+            context,
         }
     }
 
@@ -153,6 +203,9 @@ where
 
 impl<L: Contextual> Contextual for LaneGuard<L> {
     fn context(&self) -> Context {
-        self.lane.context()
+        match &self.context {
+            Some(context) => context.clone(),
+            None => self.lane.context(),
+        }
     }
 }

--- a/components/jetstream_rpc/src/session/lifetime.rs
+++ b/components/jetstream_rpc/src/session/lifetime.rs
@@ -61,6 +61,15 @@ impl LaneLifetime {
         }
     }
 
+    /// Whether the session has closed, without needing a waker.
+    ///
+    /// r[impl jetstream.session.lifetime]
+    /// `start_send` commits a write and has no context to register, so
+    /// it needs a synchronous answer.
+    pub(crate) fn is_closed(&self) -> bool {
+        self.token.is_cancelled()
+    }
+
     /// Whether the session has closed, registering `cx` if it has not.
     pub(crate) fn poll_closed(&mut self, cx: &mut TaskContext<'_>) -> bool {
         if self.token.is_cancelled() {

--- a/components/jetstream_rpc/src/session/lifetime.rs
+++ b/components/jetstream_rpc/src/session/lifetime.rs
@@ -35,12 +35,44 @@ use crate::{
     Error,
 };
 
+/// Watches one cancellation token, registering a waker on first poll.
+///
+/// The waiter is built lazily, so a lane that is never polled costs
+/// nothing.
+pub(crate) struct CancelWatch {
+    token: CancellationToken,
+    waiter: Option<Pin<Box<WaitForCancellationFutureOwned>>>,
+}
+
+impl CancelWatch {
+    pub(crate) fn new(token: CancellationToken) -> Self {
+        Self {
+            token,
+            waiter: None,
+        }
+    }
+
+    /// Whether the token has been cancelled, without needing a waker.
+    pub(crate) fn is_cancelled(&self) -> bool {
+        self.token.is_cancelled()
+    }
+
+    /// Whether the token has been cancelled, registering `cx` if not.
+    pub(crate) fn poll_cancelled(&mut self, cx: &mut TaskContext<'_>) -> bool {
+        if self.token.is_cancelled() {
+            return true;
+        }
+        if self.waiter.is_none() {
+            self.waiter = Some(Box::pin(self.token.clone().cancelled_owned()));
+        }
+        let waiter = self.waiter.as_mut().expect("waiter was just constructed");
+        matches!(waiter.as_mut().poll(cx), Poll::Ready(()))
+    }
+}
+
 /// One lane's share of its session's lifetime.
 pub(crate) struct LaneLifetime {
-    token: CancellationToken,
-    /// Built on first poll, so that a lane which is never polled costs
-    /// nothing.
-    waiter: Option<Pin<Box<WaitForCancellationFutureOwned>>>,
+    watch: CancelWatch,
     /// Whether the closure has already been reported to the reader, so
     /// that a closed lane reports once and then ends.
     pub(crate) reported: bool,
@@ -54,8 +86,7 @@ impl LaneLifetime {
     ) -> Self {
         live.fetch_add(1, Ordering::SeqCst);
         Self {
-            token,
-            waiter: None,
+            watch: CancelWatch::new(token),
             reported: false,
             live,
         }
@@ -67,19 +98,12 @@ impl LaneLifetime {
     /// `start_send` commits a write and has no context to register, so
     /// it needs a synchronous answer.
     pub(crate) fn is_closed(&self) -> bool {
-        self.token.is_cancelled()
+        self.watch.is_cancelled()
     }
 
     /// Whether the session has closed, registering `cx` if it has not.
     pub(crate) fn poll_closed(&mut self, cx: &mut TaskContext<'_>) -> bool {
-        if self.token.is_cancelled() {
-            return true;
-        }
-        if self.waiter.is_none() {
-            self.waiter = Some(Box::pin(self.token.clone().cancelled_owned()));
-        }
-        let waiter = self.waiter.as_mut().expect("waiter was just constructed");
-        matches!(waiter.as_mut().poll(cx), Poll::Ready(()))
+        self.watch.poll_cancelled(cx)
     }
 }
 

--- a/components/jetstream_rpc/src/session/lifetime.rs
+++ b/components/jetstream_rpc/src/session/lifetime.rs
@@ -166,7 +166,13 @@ where
     }
 
     fn start_send(self: Pin<&mut Self>, item: Item) -> Result<(), Self::Error> {
-        Pin::new(&mut self.get_mut().lane).start_send(item)
+        let this = self.get_mut();
+        // r[impl jetstream.session.lifetime]
+        // `poll_ready` may have said yes before the session closed.
+        if this.lifetime.is_closed() {
+            return Err(SessionError::Closed.into());
+        }
+        Pin::new(&mut this.lane).start_send(item)
     }
 
     fn poll_flush(

--- a/components/jetstream_rpc/src/session/local.rs
+++ b/components/jetstream_rpc/src/session/local.rs
@@ -110,7 +110,15 @@ impl<P: Protocol> LocalSession<P> {
 
     /// A connected pair whose lanes hold `capacity` frames before
     /// applying backpressure.
+    /// # Panics
+    ///
+    /// If `capacity` is zero. A lane with no room for a frame cannot
+    /// apply backpressure, it can only deadlock, and the bounded channel
+    /// underneath rejects it — better to say so at construction than to
+    /// panic inside the first `open_lane`.
     pub fn pair_with_capacity(capacity: usize) -> LocalSessionPair<P> {
+        assert!(capacity > 0, "a lane needs room for at least one frame");
+
         let (client_offers, from_client) = mpsc::unbounded_channel();
         let (server_offers, from_server) = mpsc::unbounded_channel();
 
@@ -394,14 +402,26 @@ impl<P: Protocol> OrderedSender<P> {
             }
         }
 
+        // r[impl jetstream.session.lifetime]
+        // Checked again here: the wait above can have handed back a turn
+        // that the session outlived.
+        if self.cancel.is_cancelled() {
+            ticket.complete();
+            return Err(SessionError::Closed);
+        }
+
         let result = {
             let sending = self.tx.send(frame);
             let closing = self.cancel.cancelled();
             pin_mut!(sending);
             pin_mut!(closing);
-            match select(sending, closing).await {
-                Either::Left((result, _)) => result,
-                Either::Right(_) => {
+            // Cancellation is the left arm deliberately. `select` polls
+            // left first, so when a close and a ready channel are both
+            // available the close wins rather than the frame going out
+            // on a session that has already ended.
+            match select(closing, sending).await {
+                Either::Right((result, _)) => result,
+                Either::Left(_) => {
                     // The place still passes on: the lane is gone, but
                     // nothing may overtake what this ticket held.
                     ticket.complete();

--- a/components/jetstream_rpc/src/session/local.rs
+++ b/components/jetstream_rpc/src/session/local.rs
@@ -22,17 +22,18 @@ use std::{
 };
 
 use futures::{
-    channel::{mpsc, oneshot},
+    channel::oneshot,
     future::{select, Either},
-    pin_mut, Future, Sink, SinkExt, Stream, StreamExt,
+    pin_mut, Sink, Stream,
 };
-use tokio::sync::{Mutex, Notify};
+use tokio::sync::{mpsc, Mutex, Notify};
+use tokio_util::sync::PollSender;
 
 use crate::{
     context::{Context, Contextual},
     session::{
-        capabilities::Capabilities, error::SessionError, order::LaneOrder,
-        OrderTicket, Session,
+        capabilities::Capabilities, error::SessionError,
+        lifetime::LaneLifetime, order::LaneOrder, OrderTicket, Session,
     },
     Error, Frame, Protocol,
 };
@@ -43,6 +44,16 @@ use crate::{
 /// The lane's `Sink` reports pending once this many frames are
 /// undelivered, rather than buffering without bound.
 pub const DEFAULT_LANE_CAPACITY: usize = 64;
+
+/// The lane's send half.
+///
+/// `PollSender` rather than a `Sink` over `futures::channel::mpsc`
+/// deliberately: a `futures` sender whose send future is dropped while
+/// pending — a `select!` arm that loses, a write under a timeout —
+/// refuses every later write on that sender, which would wedge a lane
+/// for the ordinary act of cancelling a write. `PollSender` holds the
+/// reservation across the drop instead.
+type LaneSender<T> = PollSender<T>;
 
 /// What one peer hands the other when it opens a lane: the callee's two
 /// halves of the new lane.
@@ -101,8 +112,8 @@ impl<P: Protocol> LocalSession<P> {
     /// A connected pair whose lanes hold `capacity` frames before
     /// applying backpressure.
     pub fn pair_with_capacity(capacity: usize) -> LocalSessionPair<P> {
-        let (client_offers, from_client) = mpsc::unbounded();
-        let (server_offers, from_server) = mpsc::unbounded();
+        let (client_offers, from_client) = mpsc::unbounded_channel();
+        let (server_offers, from_server) = mpsc::unbounded_channel();
         LocalSessionPair {
             client: LocalSession {
                 inner: Arc::new(SessionInner::new(
@@ -135,8 +146,31 @@ impl<P: Protocol> LocalSession<P> {
         if self.is_closed() {
             return Err(SessionError::Closed);
         }
+        // A lane that has been dropped has cancelled its half of the
+        // token; its entry is dead weight, so drop it here rather than
+        // holding one allocation per lane the session has ever opened.
+        lanes.retain(|token| !token.is_canceled());
         lanes.push(tx);
         Ok(LaneLifetime::new(rx))
+    }
+
+    /// How many lanes this session is currently keeping alive. Prunes
+    /// the entries of lanes that have since been dropped.
+    pub fn live_lanes(&self) -> usize {
+        let mut lanes =
+            self.inner.lanes.lock().expect("session lanes poisoned");
+        lanes.retain(|token| !token.is_canceled());
+        lanes.len()
+    }
+
+    /// Raw token slots, pruned or not — what a leak would grow.
+    #[cfg(test)]
+    pub(crate) fn token_slots(&self) -> usize {
+        self.inner
+            .lanes
+            .lock()
+            .expect("session lanes poisoned")
+            .len()
     }
 }
 
@@ -213,11 +247,12 @@ where
 
         self.inner
             .peer_offers
-            .unbounded_send((responses_tx, requests_rx))
+            .send((responses_tx, requests_rx))
             .map_err(|_| SessionError::Closed)?;
 
         Ok(LocalClientLane {
-            tx: requests_tx,
+            tx: PollSender::new(requests_tx.clone()),
+            sender: requests_tx,
             rx: responses_rx,
             order: LaneOrder::new(),
             lifetime,
@@ -231,7 +266,15 @@ where
         }
         let offer = {
             let mut offers = self.inner.offers.lock().await;
-            let next = offers.next();
+            // r[impl jetstream.session.lifetime]
+            // Re-check under the lock: a task that waited here while
+            // another held the lock would otherwise build its `notified`
+            // future after `close` had already woken the waiters, and
+            // wait for a notification that had already been sent.
+            if self.is_closed() {
+                return Err(SessionError::Closed);
+            }
+            let next = offers.recv();
             let closing = self.inner.closing.notified();
             pin_mut!(next);
             pin_mut!(closing);
@@ -244,7 +287,7 @@ where
         let (tx, rx) = offer.ok_or(SessionError::Closed)?;
         let lifetime = self.register_lane()?;
         Ok(LocalServiceLane {
-            tx,
+            tx: PollSender::new(tx),
             rx,
             lifetime,
             _p: PhantomData,
@@ -266,38 +309,11 @@ where
     }
 }
 
-/// A lane's share of its session's lifetime.
-struct LaneLifetime {
-    token: Option<oneshot::Receiver<()>>,
-    reported: bool,
-}
-
-impl LaneLifetime {
-    fn new(token: oneshot::Receiver<()>) -> Self {
-        Self {
-            token: Some(token),
-            reported: false,
-        }
-    }
-
-    /// Whether the session has closed, registering `cx` if it has not.
-    fn poll_closed(&mut self, cx: &mut TaskContext<'_>) -> bool {
-        let Some(token) = self.token.as_mut() else {
-            return true;
-        };
-        match Pin::new(token).poll(cx) {
-            Poll::Ready(_) => {
-                self.token = None;
-                true
-            }
-            Poll::Pending => false,
-        }
-    }
-}
-
 /// The caller's end of an in-process lane.
 pub struct LocalClientLane<P: Protocol> {
-    tx: mpsc::Sender<Frame<P::Request>>,
+    tx: LaneSender<Frame<P::Request>>,
+    /// A spare handle on the same channel, for [`OrderedSender`] clones.
+    sender: mpsc::Sender<Frame<P::Request>>,
     rx: mpsc::Receiver<Frame<P::Response>>,
     order: LaneOrder,
     lifetime: LaneLifetime,
@@ -312,7 +328,7 @@ impl<P: Protocol> LocalClientLane<P> {
     /// producers do: use one or the other on a given lane, not both.
     pub fn ordered_sender(&self) -> OrderedSender<P> {
         OrderedSender {
-            tx: Arc::new(Mutex::new(self.tx.clone())),
+            tx: self.sender.clone(),
             order: self.order.clone(),
         }
     }
@@ -326,7 +342,7 @@ impl<P: Protocol> LocalClientLane<P> {
 /// to [`OrderedSender::deliver`]. A ticket dropped without delivering
 /// passes its place on rather than releasing it.
 pub struct OrderedSender<P: Protocol> {
-    tx: Arc<Mutex<mpsc::Sender<Frame<P::Request>>>>,
+    tx: mpsc::Sender<Frame<P::Request>>,
     order: LaneOrder,
 }
 
@@ -352,10 +368,7 @@ impl<P: Protocol> OrderedSender<P> {
         frame: Frame<P::Request>,
     ) -> Result<(), SessionError> {
         ticket.wait().await;
-        let result = {
-            let mut tx = self.tx.lock().await;
-            tx.send(frame).await
-        };
+        let result = self.tx.send(frame).await;
         ticket.complete();
         result.map_err(|_| SessionError::LaneClosed)
     }
@@ -371,7 +384,7 @@ impl<P: Protocol> OrderedSender<P> {
     }
 }
 
-impl<P: Protocol> Sink<Frame<P::Request>> for LocalClientLane<P> {
+impl<P: Protocol + 'static> Sink<Frame<P::Request>> for LocalClientLane<P> {
     type Error = Error;
 
     fn poll_ready(
@@ -430,19 +443,19 @@ impl<P: Protocol> Stream for LocalClientLane<P> {
             this.lifetime.reported = true;
             return Poll::Ready(Some(Err(SessionError::Closed.into())));
         }
-        Pin::new(&mut this.rx).poll_next(cx).map(|f| f.map(Ok))
+        this.rx.poll_recv(cx).map(|frame| frame.map(Ok))
     }
 }
 
 /// The callee's end of an in-process lane.
 pub struct LocalServiceLane<P: Protocol> {
-    tx: mpsc::Sender<Frame<P::Response>>,
+    tx: LaneSender<Frame<P::Response>>,
     rx: mpsc::Receiver<Frame<P::Request>>,
     lifetime: LaneLifetime,
     _p: PhantomData<fn() -> P>,
 }
 
-impl<P: Protocol> Sink<Frame<P::Response>> for LocalServiceLane<P> {
+impl<P: Protocol + 'static> Sink<Frame<P::Response>> for LocalServiceLane<P> {
     type Error = Error;
 
     fn poll_ready(
@@ -501,7 +514,7 @@ impl<P: Protocol> Stream for LocalServiceLane<P> {
             this.lifetime.reported = true;
             return Poll::Ready(Some(Err(SessionError::Closed.into())));
         }
-        Pin::new(&mut this.rx).poll_next(cx).map(|f| f.map(Ok))
+        this.rx.poll_recv(cx).map(|frame| frame.map(Ok))
     }
 }
 

--- a/components/jetstream_rpc/src/session/local.rs
+++ b/components/jetstream_rpc/src/session/local.rs
@@ -281,6 +281,7 @@ where
             rx: responses_rx,
             order: LaneOrder::new(),
             cancel,
+            session: self.inner.cancel.clone(),
             lifetime,
             _p: PhantomData,
         })
@@ -336,8 +337,11 @@ pub struct LocalClientLane<P: Protocol> {
     rx: mpsc::Receiver<Frame<P::Response>>,
     order: LaneOrder,
     /// Shared with every [`OrderedSender`] this lane hands out, so they
-    /// observe the session's closure too.
+    /// observe closure too. Cancelled by closing this lane *or* the
+    /// session, since it is a child of `session`.
     cancel: CancellationToken,
+    /// The session's token, so a sender can say which of the two ended.
+    session: CancellationToken,
     lifetime: LaneLifetime,
     _p: PhantomData<fn() -> P>,
 }
@@ -357,6 +361,7 @@ impl<P: Protocol> LocalClientLane<P> {
             tx,
             order: self.order.clone(),
             cancel: self.cancel.clone(),
+            session: self.session.clone(),
         })
     }
 }
@@ -373,9 +378,19 @@ pub struct OrderedSender<P: Protocol> {
     order: LaneOrder,
     /// r[impl jetstream.session.lifetime]
     /// A sender outlives the lane value it was taken from, so it has to
-    /// observe the session's closure itself: otherwise closing a session
-    /// would leave behind a handle that could still reach the peer.
+    /// observe closure itself: otherwise closing a session would leave
+    /// behind a handle that could still reach the peer. This is the
+    /// *lane's* token, cancelled when either the lane or the session
+    /// closes — it is a child of the one below.
     cancel: CancellationToken,
+    /// r[impl jetstream.session.lifetime]
+    /// The session's own token, kept only to tell the two causes apart
+    /// when reporting. `SessionError::Closed` says the association is
+    /// over, which is what a caller decides to stop retrying on;
+    /// `LaneClosed` says this lane is done and another may still open.
+    /// Since the lane token is a child, cancellation alone cannot
+    /// distinguish them.
+    session: CancellationToken,
 }
 
 impl<P: Protocol> Clone for OrderedSender<P> {
@@ -383,6 +398,7 @@ impl<P: Protocol> Clone for OrderedSender<P> {
         Self {
             tx: self.tx.clone(),
             order: self.order.clone(),
+            session: self.session.clone(),
             cancel: self.cancel.clone(),
         }
     }
@@ -395,13 +411,27 @@ impl<P: Protocol> OrderedSender<P> {
     }
 
     /// Deliver `frame` when its ticket's turn comes.
+    /// Why this sender stopped: the session ending, or only its lane.
+    ///
+    /// r[impl jetstream.session.lifetime]
+    /// Closing a lane does not close its session, so a sender that
+    /// reported `Closed` for a lane-only close would tell a caller the
+    /// association was over when another lane could still be opened.
+    fn ended(&self) -> SessionError {
+        if self.session.is_cancelled() {
+            SessionError::Closed
+        } else {
+            SessionError::LaneClosed
+        }
+    }
+
     pub async fn deliver(
         &self,
         ticket: OrderTicket,
         frame: Frame<P::Request>,
     ) -> Result<(), SessionError> {
         if self.cancel.is_cancelled() {
-            return Err(SessionError::Closed);
+            return Err(self.ended());
         }
 
         // r[impl jetstream.session.lifetime]
@@ -413,7 +443,7 @@ impl<P: Protocol> OrderedSender<P> {
             pin_mut!(waiting);
             pin_mut!(closing);
             if matches!(select(waiting, closing).await, Either::Right(_)) {
-                return Err(SessionError::Closed);
+                return Err(self.ended());
             }
         }
 
@@ -422,7 +452,7 @@ impl<P: Protocol> OrderedSender<P> {
         // that the session outlived.
         if self.cancel.is_cancelled() {
             ticket.complete();
-            return Err(SessionError::Closed);
+            return Err(self.ended());
         }
 
         let result = {
@@ -440,7 +470,7 @@ impl<P: Protocol> OrderedSender<P> {
                     // The place still passes on: the lane is gone, but
                     // nothing may overtake what this ticket held.
                     ticket.complete();
-                    return Err(SessionError::Closed);
+                    return Err(self.ended());
                 }
             }
         };

--- a/components/jetstream_rpc/src/session/local.rs
+++ b/components/jetstream_rpc/src/session/local.rs
@@ -15,19 +15,18 @@ use std::{
     marker::PhantomData,
     pin::Pin,
     sync::{
-        atomic::{AtomicBool, Ordering as AtomicOrdering},
-        Arc, Mutex as StdMutex,
+        atomic::{AtomicUsize, Ordering as AtomicOrdering},
+        Arc,
     },
     task::{Context as TaskContext, Poll},
 };
 
 use futures::{
-    channel::oneshot,
     future::{select, Either},
     pin_mut, Sink, Stream,
 };
-use tokio::sync::{mpsc, Mutex, Notify};
-use tokio_util::sync::PollSender;
+use tokio::sync::{mpsc, Mutex};
+use tokio_util::sync::{CancellationToken, PollSender};
 
 use crate::{
     context::{Context, Contextual},
@@ -67,11 +66,11 @@ struct SessionInner<P: Protocol> {
     peer_offers: mpsc::UnboundedSender<LaneOffer<P>>,
     /// Lanes the peer opened, waiting to be accepted.
     offers: Mutex<mpsc::UnboundedReceiver<LaneOffer<P>>>,
-    /// One token per live lane. Dropping a token terminates its lane.
-    lanes: StdMutex<Vec<oneshot::Sender<()>>>,
-    /// Wakes anything parked in `accept_lane` when the session closes.
-    closing: Notify,
-    closed: AtomicBool,
+    /// r[impl jetstream.session.lifetime]
+    /// Cancelled by `close`. Every lane holds a child of it, and so does
+    /// every [`OrderedSender`] taken from a lane.
+    cancel: CancellationToken,
+    live: Arc<AtomicUsize>,
     capacity: usize,
 }
 
@@ -133,44 +132,28 @@ impl<P: Protocol> LocalSession<P> {
     }
 
     fn is_closed(&self) -> bool {
-        self.inner.closed.load(AtomicOrdering::SeqCst)
+        self.inner.cancel.is_cancelled()
     }
 
     /// r[impl jetstream.session.lifetime]
-    /// Every lane holds a token owned by its session, so a lane cannot
-    /// outlive the session that opened it.
+    /// A lane's share of this session's lifetime. A child taken from an
+    /// already-cancelled token is born cancelled, so a lane opened
+    /// concurrently with `close` cannot escape it, and a dropped child
+    /// deregisters itself, so a session that opens many short-lived
+    /// lanes does not accumulate an entry per lane it has ever opened.
     fn register_lane(&self) -> Result<LaneLifetime, SessionError> {
-        let (tx, rx) = oneshot::channel();
-        let mut lanes =
-            self.inner.lanes.lock().expect("session lanes poisoned");
         if self.is_closed() {
             return Err(SessionError::Closed);
         }
-        // A lane that has been dropped has cancelled its half of the
-        // token; its entry is dead weight, so drop it here rather than
-        // holding one allocation per lane the session has ever opened.
-        lanes.retain(|token| !token.is_canceled());
-        lanes.push(tx);
-        Ok(LaneLifetime::new(rx))
+        Ok(LaneLifetime::new(
+            self.inner.cancel.child_token(),
+            self.inner.live.clone(),
+        ))
     }
 
-    /// How many lanes this session is currently keeping alive. Prunes
-    /// the entries of lanes that have since been dropped.
+    /// How many lanes this session is currently keeping alive.
     pub fn live_lanes(&self) -> usize {
-        let mut lanes =
-            self.inner.lanes.lock().expect("session lanes poisoned");
-        lanes.retain(|token| !token.is_canceled());
-        lanes.len()
-    }
-
-    /// Raw token slots, pruned or not — what a leak would grow.
-    #[cfg(test)]
-    pub(crate) fn token_slots(&self) -> usize {
-        self.inner
-            .lanes
-            .lock()
-            .expect("session lanes poisoned")
-            .len()
+        self.inner.live.load(AtomicOrdering::SeqCst)
     }
 }
 
@@ -183,9 +166,8 @@ impl<P: Protocol> SessionInner<P> {
         Self {
             peer_offers,
             offers: Mutex::new(offers),
-            lanes: StdMutex::new(Vec::new()),
-            closing: Notify::new(),
-            closed: AtomicBool::new(false),
+            cancel: CancellationToken::new(),
+            live: Arc::new(AtomicUsize::new(0)),
             capacity,
         }
     }
@@ -255,6 +237,7 @@ where
             sender: requests_tx,
             rx: responses_rx,
             order: LaneOrder::new(),
+            cancel: self.inner.cancel.child_token(),
             lifetime,
             _p: PhantomData,
         })
@@ -275,7 +258,7 @@ where
                 return Err(SessionError::Closed);
             }
             let next = offers.recv();
-            let closing = self.inner.closing.notified();
+            let closing = self.inner.cancel.cancelled();
             pin_mut!(next);
             pin_mut!(closing);
             match select(next, closing).await {
@@ -299,13 +282,7 @@ where
     /// opened or accepted: their streams end and their sinks fail, so a
     /// call in flight fails rather than hanging.
     async fn close(&self) {
-        self.inner.closed.store(true, AtomicOrdering::SeqCst);
-        self.inner
-            .lanes
-            .lock()
-            .expect("session lanes poisoned")
-            .clear();
-        self.inner.closing.notify_waiters();
+        self.inner.cancel.cancel();
     }
 }
 
@@ -316,6 +293,9 @@ pub struct LocalClientLane<P: Protocol> {
     sender: mpsc::Sender<Frame<P::Request>>,
     rx: mpsc::Receiver<Frame<P::Response>>,
     order: LaneOrder,
+    /// Shared with every [`OrderedSender`] this lane hands out, so they
+    /// observe the session's closure too.
+    cancel: CancellationToken,
     lifetime: LaneLifetime,
     _p: PhantomData<fn() -> P>,
 }
@@ -330,6 +310,7 @@ impl<P: Protocol> LocalClientLane<P> {
         OrderedSender {
             tx: self.sender.clone(),
             order: self.order.clone(),
+            cancel: self.cancel.clone(),
         }
     }
 }
@@ -344,6 +325,11 @@ impl<P: Protocol> LocalClientLane<P> {
 pub struct OrderedSender<P: Protocol> {
     tx: mpsc::Sender<Frame<P::Request>>,
     order: LaneOrder,
+    /// r[impl jetstream.session.lifetime]
+    /// A sender outlives the lane value it was taken from, so it has to
+    /// observe the session's closure itself: otherwise closing a session
+    /// would leave behind a handle that could still reach the peer.
+    cancel: CancellationToken,
 }
 
 impl<P: Protocol> Clone for OrderedSender<P> {
@@ -351,6 +337,7 @@ impl<P: Protocol> Clone for OrderedSender<P> {
         Self {
             tx: self.tx.clone(),
             order: self.order.clone(),
+            cancel: self.cancel.clone(),
         }
     }
 }
@@ -367,8 +354,38 @@ impl<P: Protocol> OrderedSender<P> {
         ticket: OrderTicket,
         frame: Frame<P::Request>,
     ) -> Result<(), SessionError> {
-        ticket.wait().await;
-        let result = self.tx.send(frame).await;
+        if self.cancel.is_cancelled() {
+            return Err(SessionError::Closed);
+        }
+
+        // r[impl jetstream.session.lifetime]
+        // Waiting for this ticket's turn, and then for room on the
+        // lane, both have to give up if the session closes underneath.
+        {
+            let waiting = ticket.wait();
+            let closing = self.cancel.cancelled();
+            pin_mut!(waiting);
+            pin_mut!(closing);
+            if matches!(select(waiting, closing).await, Either::Right(_)) {
+                return Err(SessionError::Closed);
+            }
+        }
+
+        let result = {
+            let sending = self.tx.send(frame);
+            let closing = self.cancel.cancelled();
+            pin_mut!(sending);
+            pin_mut!(closing);
+            match select(sending, closing).await {
+                Either::Left((result, _)) => result,
+                Either::Right(_) => {
+                    // The place still passes on: the lane is gone, but
+                    // nothing may overtake what this ticket held.
+                    ticket.complete();
+                    return Err(SessionError::Closed);
+                }
+            }
+        };
         ticket.complete();
         result.map_err(|_| SessionError::LaneClosed)
     }

--- a/components/jetstream_rpc/src/session/local.rs
+++ b/components/jetstream_rpc/src/session/local.rs
@@ -411,6 +411,17 @@ impl<P: Protocol> OrderedSender<P> {
     }
 
     /// Deliver `frame` when its ticket's turn comes.
+    ///
+    /// # Panics
+    ///
+    /// r[impl jetstream.session.local.order-handoff]
+    /// If `ticket` came from another lane's order. Every lane's
+    /// `admit` returns the same type, so the mix-up is not a type
+    /// error; it is a caller bug, and a silent one — the delivery would
+    /// wait on the other lane's sequence while writing to this one,
+    /// stalling behind a place it does not hold or overtaking one it
+    /// should have waited for. Rejected here rather than honoured,
+    /// for the same reason a zero-capacity lane is.
     /// Why this sender stopped: the session ending, or only its lane.
     ///
     /// r[impl jetstream.session.lifetime]
@@ -430,6 +441,11 @@ impl<P: Protocol> OrderedSender<P> {
         ticket: OrderTicket,
         frame: Frame<P::Request>,
     ) -> Result<(), SessionError> {
+        assert!(
+            self.order.issued(&ticket),
+            "an ordered send was given a ticket from another lane"
+        );
+
         if self.cancel.is_cancelled() {
             return Err(self.ended());
         }

--- a/components/jetstream_rpc/src/session/local.rs
+++ b/components/jetstream_rpc/src/session/local.rs
@@ -31,7 +31,8 @@ use tokio_util::sync::{CancellationToken, PollSender};
 use crate::{
     context::{Context, Contextual},
     session::{
-        capabilities::Capabilities, error::SessionError,
+        capabilities::Capabilities,
+        error::SessionError,
         lifetime::{CancelWatch, LaneLifetime},
         order::LaneOrder,
         OrderTicket, Session,
@@ -625,10 +626,20 @@ impl<P: Protocol> Stream for LocalServiceLane<P> {
             // open: whether the lane is over is a property of the lane,
             // not of how many handles happen to survive.
             Poll::Pending => {
-                if this.peer_closed.poll_cancelled(cx) {
-                    Poll::Ready(None)
-                } else {
-                    Poll::Pending
+                if !this.peer_closed.poll_cancelled(cx) {
+                    return Poll::Pending;
+                }
+                // r[impl jetstream.lane.definition]
+                // Read again before reporting the end. A frame can be
+                // queued between the empty read above and the
+                // cancellation here, and returning `None` at that point
+                // would end the stream while a frame the opener sent —
+                // and whose send returned success — is still sitting in
+                // it. The wake that enqueue posts is no help once the
+                // stream has said it is over.
+                match this.rx.poll_recv(cx) {
+                    Poll::Ready(frame) => Poll::Ready(frame.map(Ok)),
+                    Poll::Pending => Poll::Ready(None),
                 }
             }
         }

--- a/components/jetstream_rpc/src/session/local.rs
+++ b/components/jetstream_rpc/src/session/local.rs
@@ -113,12 +113,22 @@ impl<P: Protocol> LocalSession<P> {
     pub fn pair_with_capacity(capacity: usize) -> LocalSessionPair<P> {
         let (client_offers, from_client) = mpsc::unbounded_channel();
         let (server_offers, from_server) = mpsc::unbounded_channel();
+
+        // r[impl jetstream.session.lifetime]
+        // One token for the association, not one per end. A lane has two
+        // ends, and closing from either has to terminate both: a peer
+        // left holding the far end of a lane whose opener has gone would
+        // wait on it forever. This is what a transport-backed session
+        // gets for free — the connection goes away for both peers.
+        let cancel = CancellationToken::new();
+
         LocalSessionPair {
             client: LocalSession {
                 inner: Arc::new(SessionInner::new(
                     client_offers,
                     from_server,
                     capacity,
+                    cancel.clone(),
                 )),
             },
             server: LocalSession {
@@ -126,6 +136,7 @@ impl<P: Protocol> LocalSession<P> {
                     server_offers,
                     from_client,
                     capacity,
+                    cancel,
                 )),
             },
         }
@@ -162,11 +173,12 @@ impl<P: Protocol> SessionInner<P> {
         peer_offers: mpsc::UnboundedSender<LaneOffer<P>>,
         offers: mpsc::UnboundedReceiver<LaneOffer<P>>,
         capacity: usize,
+        cancel: CancellationToken,
     ) -> Self {
         Self {
             peer_offers,
             offers: Mutex::new(offers),
-            cancel: CancellationToken::new(),
+            cancel,
             live: Arc::new(AtomicUsize::new(0)),
             capacity,
         }
@@ -199,6 +211,17 @@ impl<P: Protocol> fmt::Debug for OrderedSender<P> {
         f.debug_struct("OrderedSender")
             .field("turn", &self.order.turn())
             .finish_non_exhaustive()
+    }
+}
+
+/// r[impl jetstream.session.lifetime]
+/// Dropping the last handle on a session ends it. A cancellation token
+/// does not cancel when it is dropped, so without this a session that
+/// went away during error unwinding — rather than through `close` —
+/// would leave its lanes usable and its pending calls waiting.
+impl<P: Protocol> Drop for SessionInner<P> {
+    fn drop(&mut self) {
+        self.cancel.cancel();
     }
 }
 
@@ -421,7 +444,13 @@ impl<P: Protocol + 'static> Sink<Frame<P::Request>> for LocalClientLane<P> {
         self: Pin<&mut Self>,
         item: Frame<P::Request>,
     ) -> Result<(), Self::Error> {
-        Pin::new(&mut self.get_mut().tx)
+        let this = self.get_mut();
+        // r[impl jetstream.session.lifetime]
+        // `poll_ready` may have said yes before the session closed.
+        if this.lifetime.is_closed() {
+            return Err(SessionError::Closed.into());
+        }
+        Pin::new(&mut this.tx)
             .start_send(item)
             .map_err(|_| SessionError::LaneClosed.into())
     }
@@ -492,7 +521,13 @@ impl<P: Protocol + 'static> Sink<Frame<P::Response>> for LocalServiceLane<P> {
         self: Pin<&mut Self>,
         item: Frame<P::Response>,
     ) -> Result<(), Self::Error> {
-        Pin::new(&mut self.get_mut().tx)
+        let this = self.get_mut();
+        // r[impl jetstream.session.lifetime]
+        // `poll_ready` may have said yes before the session closed.
+        if this.lifetime.is_closed() {
+            return Err(SessionError::Closed.into());
+        }
+        Pin::new(&mut this.tx)
             .start_send(item)
             .map_err(|_| SessionError::LaneClosed.into())
     }

--- a/components/jetstream_rpc/src/session/local.rs
+++ b/components/jetstream_rpc/src/session/local.rs
@@ -32,7 +32,9 @@ use crate::{
     context::{Context, Contextual},
     session::{
         capabilities::Capabilities, error::SessionError,
-        lifetime::LaneLifetime, order::LaneOrder, OrderTicket, Session,
+        lifetime::{CancelWatch, LaneLifetime},
+        order::LaneOrder,
+        OrderTicket, Session,
     },
     Error, Frame, Protocol,
 };
@@ -56,9 +58,18 @@ type LaneSender<T> = PollSender<T>;
 
 /// What one peer hands the other when it opens a lane: the callee's two
 /// halves of the new lane.
+/// What one end of a lane hands to the other: the two channel halves,
+/// and a token cancelled when the opener closes its end.
+///
+/// r[impl jetstream.lane.definition]
+/// The token is there because whether the far end has seen the last
+/// frame cannot be left to how many channel handles happen to survive:
+/// an `OrderedSender` the opener still holds would otherwise keep the
+/// peer waiting on a lane that is closed.
 type LaneOffer<P> = (
     mpsc::Sender<Frame<<P as Protocol>::Response>>,
     mpsc::Receiver<Frame<<P as Protocol>::Request>>,
+    CancellationToken,
 );
 
 struct SessionInner<P: Protocol> {
@@ -257,17 +268,18 @@ where
         let (requests_tx, requests_rx) = mpsc::channel(capacity);
         let (responses_tx, responses_rx) = mpsc::channel(capacity);
         let lifetime = self.register_lane()?;
+        let cancel = self.inner.cancel.child_token();
 
         self.inner
             .peer_offers
-            .send((responses_tx, requests_rx))
+            .send((responses_tx, requests_rx, cancel.clone()))
             .map_err(|_| SessionError::Closed)?;
 
         Ok(LocalClientLane {
             tx: PollSender::new(requests_tx),
             rx: responses_rx,
             order: LaneOrder::new(),
-            cancel: self.inner.cancel.child_token(),
+            cancel,
             lifetime,
             _p: PhantomData,
         })
@@ -297,11 +309,12 @@ where
                 Either::Right(_) => return Err(SessionError::Closed),
             }
         };
-        let (tx, rx) = offer.ok_or(SessionError::Closed)?;
+        let (tx, rx, peer_closed) = offer.ok_or(SessionError::Closed)?;
         let lifetime = self.register_lane()?;
         Ok(LocalServiceLane {
             tx: PollSender::new(tx),
             rx,
+            peer_closed: CancelWatch::new(peer_closed),
             lifetime,
             _p: PhantomData,
         })
@@ -527,6 +540,9 @@ impl<P: Protocol> Stream for LocalClientLane<P> {
 pub struct LocalServiceLane<P: Protocol> {
     tx: LaneSender<Frame<P::Response>>,
     rx: mpsc::Receiver<Frame<P::Request>>,
+    /// r[impl jetstream.lane.definition]
+    /// Cancelled when the opener closed its end of this lane.
+    peer_closed: CancelWatch,
     lifetime: LaneLifetime,
     _p: PhantomData<fn() -> P>,
 }
@@ -596,7 +612,26 @@ impl<P: Protocol> Stream for LocalServiceLane<P> {
             this.lifetime.reported = true;
             return Poll::Ready(Some(Err(SessionError::Closed.into())));
         }
-        this.rx.poll_recv(cx).map(|frame| frame.map(Ok))
+        match this.rx.poll_recv(cx) {
+            Poll::Ready(frame) => Poll::Ready(frame.map(Ok)),
+            // r[impl jetstream.lane.definition]
+            // Nothing queued *and* the opener has closed: the lane is
+            // finished. Checked in this order so that frames already
+            // written before the close are still delivered — a close
+            // says "no more items", not "discard the ones I sent".
+            //
+            // The token rather than the channel's own end-of-stream,
+            // because a writer the opener still holds keeps the channel
+            // open: whether the lane is over is a property of the lane,
+            // not of how many handles happen to survive.
+            Poll::Pending => {
+                if this.peer_closed.poll_cancelled(cx) {
+                    Poll::Ready(None)
+                } else {
+                    Poll::Pending
+                }
+            }
+        }
     }
 }
 

--- a/components/jetstream_rpc/src/session/local.rs
+++ b/components/jetstream_rpc/src/session/local.rs
@@ -264,8 +264,7 @@ where
             .map_err(|_| SessionError::Closed)?;
 
         Ok(LocalClientLane {
-            tx: PollSender::new(requests_tx.clone()),
-            sender: requests_tx,
+            tx: PollSender::new(requests_tx),
             rx: responses_rx,
             order: LaneOrder::new(),
             cancel: self.inner.cancel.child_token(),
@@ -320,8 +319,6 @@ where
 /// The caller's end of an in-process lane.
 pub struct LocalClientLane<P: Protocol> {
     tx: LaneSender<Frame<P::Request>>,
-    /// A spare handle on the same channel, for [`OrderedSender`] clones.
-    sender: mpsc::Sender<Frame<P::Request>>,
     rx: mpsc::Receiver<Frame<P::Response>>,
     order: LaneOrder,
     /// Shared with every [`OrderedSender`] this lane hands out, so they
@@ -337,12 +334,16 @@ impl<P: Protocol> LocalClientLane<P> {
     /// r[impl jetstream.session.local.order-handoff]
     /// The lane's own `Sink` is sequential and needs no help. Concurrent
     /// producers do: use one or the other on a given lane, not both.
-    pub fn ordered_sender(&self) -> OrderedSender<P> {
-        OrderedSender {
-            tx: self.sender.clone(),
+    /// A closed lane hands out no more writers: the sink's `poll_close`
+    /// retires the channel handle, and `PollSender` reports that by
+    /// giving nothing back.
+    pub fn ordered_sender(&self) -> Result<OrderedSender<P>, SessionError> {
+        let tx = self.tx.get_ref().ok_or(SessionError::LaneClosed)?.clone();
+        Ok(OrderedSender {
+            tx,
             order: self.order.clone(),
             cancel: self.cancel.clone(),
-        }
+        })
     }
 }
 
@@ -488,7 +489,16 @@ impl<P: Protocol + 'static> Sink<Frame<P::Request>> for LocalClientLane<P> {
         self: Pin<&mut Self>,
         cx: &mut TaskContext<'_>,
     ) -> Poll<Result<(), Self::Error>> {
-        Pin::new(&mut self.get_mut().tx)
+        let this = self.get_mut();
+        // r[impl jetstream.lane.definition]
+        // Closing the lane has to retire every writer on it, not just
+        // this sink. An `OrderedSender` already handed out holds a clone
+        // of the channel, so without cancelling here the peer would
+        // never see the end of the lane and a "closed" lane would go on
+        // accepting writes. This is the lane's own token, a child of the
+        // session's: closing a lane does not close its session.
+        this.cancel.cancel();
+        Pin::new(&mut this.tx)
             .poll_close(cx)
             .map_err(|_| SessionError::LaneClosed.into())
     }

--- a/components/jetstream_rpc/src/session/local.rs
+++ b/components/jetstream_rpc/src/session/local.rs
@@ -1,0 +1,515 @@
+//! Sessions between two peers in one process.
+//!
+//! r[impl jetstream.session.local]
+//! Two peers in one process hold a session without a transport. It
+//! reports many lanes, no datagrams and no identity, and its lanes give
+//! the same ordering guarantees a transport-backed lane does.
+//!
+//! r[impl jetstream.session.local.no-serialisation]
+//! Frames move between the two ends as values. Nothing is encoded to
+//! bytes to obtain ordering: ordering is what the lane provides, and
+//! in-process it is provided by the lane itself.
+
+use std::{
+    fmt,
+    marker::PhantomData,
+    pin::Pin,
+    sync::{
+        atomic::{AtomicBool, Ordering as AtomicOrdering},
+        Arc, Mutex as StdMutex,
+    },
+    task::{Context as TaskContext, Poll},
+};
+
+use futures::{
+    channel::{mpsc, oneshot},
+    future::{select, Either},
+    pin_mut, Future, Sink, SinkExt, Stream, StreamExt,
+};
+use tokio::sync::{Mutex, Notify};
+
+use crate::{
+    context::{Context, Contextual},
+    session::{
+        capabilities::Capabilities, error::SessionError, order::LaneOrder,
+        OrderTicket, Session,
+    },
+    Error, Frame, Protocol,
+};
+
+/// Frames a lane will hold before the writer is told to wait.
+///
+/// r[impl jetstream.lane.backpressure]
+/// The lane's `Sink` reports pending once this many frames are
+/// undelivered, rather than buffering without bound.
+pub const DEFAULT_LANE_CAPACITY: usize = 64;
+
+/// What one peer hands the other when it opens a lane: the callee's two
+/// halves of the new lane.
+type LaneOffer<P> = (
+    mpsc::Sender<Frame<<P as Protocol>::Response>>,
+    mpsc::Receiver<Frame<<P as Protocol>::Request>>,
+);
+
+struct SessionInner<P: Protocol> {
+    /// Lanes we open are offered to the peer down this channel.
+    peer_offers: mpsc::UnboundedSender<LaneOffer<P>>,
+    /// Lanes the peer opened, waiting to be accepted.
+    offers: Mutex<mpsc::UnboundedReceiver<LaneOffer<P>>>,
+    /// One token per live lane. Dropping a token terminates its lane.
+    lanes: StdMutex<Vec<oneshot::Sender<()>>>,
+    /// Wakes anything parked in `accept_lane` when the session closes.
+    closing: Notify,
+    closed: AtomicBool,
+    capacity: usize,
+}
+
+/// One end of an in-process session.
+///
+/// Cheap to clone; clones address the same session, which is what makes
+/// a session usable from several tasks at once.
+pub struct LocalSession<P: Protocol> {
+    inner: Arc<SessionInner<P>>,
+}
+
+impl<P: Protocol> Clone for LocalSession<P> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+/// The two ends of an in-process session.
+///
+/// r[impl jetstream.session.symmetric]
+/// The names are conventional. Either end may open a lane, and the end
+/// that opens it is the caller on it.
+pub struct LocalSessionPair<P: Protocol> {
+    /// The end that opens lanes in the usual arrangement.
+    pub client: LocalSession<P>,
+    /// The end that accepts them.
+    pub server: LocalSession<P>,
+}
+
+impl<P: Protocol> LocalSession<P> {
+    /// A connected pair of in-process sessions.
+    pub fn pair() -> LocalSessionPair<P> {
+        Self::pair_with_capacity(DEFAULT_LANE_CAPACITY)
+    }
+
+    /// A connected pair whose lanes hold `capacity` frames before
+    /// applying backpressure.
+    pub fn pair_with_capacity(capacity: usize) -> LocalSessionPair<P> {
+        let (client_offers, from_client) = mpsc::unbounded();
+        let (server_offers, from_server) = mpsc::unbounded();
+        LocalSessionPair {
+            client: LocalSession {
+                inner: Arc::new(SessionInner::new(
+                    client_offers,
+                    from_server,
+                    capacity,
+                )),
+            },
+            server: LocalSession {
+                inner: Arc::new(SessionInner::new(
+                    server_offers,
+                    from_client,
+                    capacity,
+                )),
+            },
+        }
+    }
+
+    fn is_closed(&self) -> bool {
+        self.inner.closed.load(AtomicOrdering::SeqCst)
+    }
+
+    /// r[impl jetstream.session.lifetime]
+    /// Every lane holds a token owned by its session, so a lane cannot
+    /// outlive the session that opened it.
+    fn register_lane(&self) -> Result<LaneLifetime, SessionError> {
+        let (tx, rx) = oneshot::channel();
+        let mut lanes =
+            self.inner.lanes.lock().expect("session lanes poisoned");
+        if self.is_closed() {
+            return Err(SessionError::Closed);
+        }
+        lanes.push(tx);
+        Ok(LaneLifetime::new(rx))
+    }
+}
+
+impl<P: Protocol> SessionInner<P> {
+    fn new(
+        peer_offers: mpsc::UnboundedSender<LaneOffer<P>>,
+        offers: mpsc::UnboundedReceiver<LaneOffer<P>>,
+        capacity: usize,
+    ) -> Self {
+        Self {
+            peer_offers,
+            offers: Mutex::new(offers),
+            lanes: StdMutex::new(Vec::new()),
+            closing: Notify::new(),
+            closed: AtomicBool::new(false),
+            capacity,
+        }
+    }
+}
+
+impl<P: Protocol> fmt::Debug for LocalSession<P> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("LocalSession")
+            .field("closed", &self.is_closed())
+            .field("capacity", &self.inner.capacity)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<P: Protocol> fmt::Debug for LocalClientLane<P> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("LocalClientLane").finish_non_exhaustive()
+    }
+}
+
+impl<P: Protocol> fmt::Debug for LocalServiceLane<P> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("LocalServiceLane").finish_non_exhaustive()
+    }
+}
+
+impl<P: Protocol> fmt::Debug for OrderedSender<P> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("OrderedSender")
+            .field("turn", &self.order.turn())
+            .finish_non_exhaustive()
+    }
+}
+
+#[async_trait::async_trait]
+impl<P> Session<P> for LocalSession<P>
+where
+    P: Protocol<Error = Error> + 'static,
+{
+    type ClientLane = LocalClientLane<P>;
+    type ServiceLane = LocalServiceLane<P>;
+
+    /// r[impl jetstream.session.local]
+    fn capabilities(&self) -> Capabilities {
+        Capabilities::in_process()
+    }
+
+    /// r[impl jetstream.lane.independence]
+    /// Each lane is its own pair of channels, so a stalled lane holds up
+    /// nothing but itself.
+    async fn open_lane(&self) -> Result<Self::ClientLane, SessionError> {
+        if self.is_closed() {
+            return Err(SessionError::Closed);
+        }
+        let capacity = self.inner.capacity;
+        let (requests_tx, requests_rx) = mpsc::channel(capacity);
+        let (responses_tx, responses_rx) = mpsc::channel(capacity);
+        let lifetime = self.register_lane()?;
+
+        self.inner
+            .peer_offers
+            .unbounded_send((responses_tx, requests_rx))
+            .map_err(|_| SessionError::Closed)?;
+
+        Ok(LocalClientLane {
+            tx: requests_tx,
+            rx: responses_rx,
+            order: LaneOrder::new(),
+            lifetime,
+            _p: PhantomData,
+        })
+    }
+
+    async fn accept_lane(&self) -> Result<Self::ServiceLane, SessionError> {
+        if self.is_closed() {
+            return Err(SessionError::Closed);
+        }
+        let offer = {
+            let mut offers = self.inner.offers.lock().await;
+            let next = offers.next();
+            let closing = self.inner.closing.notified();
+            pin_mut!(next);
+            pin_mut!(closing);
+            match select(next, closing).await {
+                Either::Left((offer, _)) => offer,
+                // r[impl jetstream.session.lifetime]
+                Either::Right(_) => return Err(SessionError::Closed),
+            }
+        };
+        let (tx, rx) = offer.ok_or(SessionError::Closed)?;
+        let lifetime = self.register_lane()?;
+        Ok(LocalServiceLane {
+            tx,
+            rx,
+            lifetime,
+            _p: PhantomData,
+        })
+    }
+
+    /// r[impl jetstream.session.lifetime]
+    /// Dropping the lane tokens terminates every lane this session
+    /// opened or accepted: their streams end and their sinks fail, so a
+    /// call in flight fails rather than hanging.
+    async fn close(&self) {
+        self.inner.closed.store(true, AtomicOrdering::SeqCst);
+        self.inner
+            .lanes
+            .lock()
+            .expect("session lanes poisoned")
+            .clear();
+        self.inner.closing.notify_waiters();
+    }
+}
+
+/// A lane's share of its session's lifetime.
+struct LaneLifetime {
+    token: Option<oneshot::Receiver<()>>,
+    reported: bool,
+}
+
+impl LaneLifetime {
+    fn new(token: oneshot::Receiver<()>) -> Self {
+        Self {
+            token: Some(token),
+            reported: false,
+        }
+    }
+
+    /// Whether the session has closed, registering `cx` if it has not.
+    fn poll_closed(&mut self, cx: &mut TaskContext<'_>) -> bool {
+        let Some(token) = self.token.as_mut() else {
+            return true;
+        };
+        match Pin::new(token).poll(cx) {
+            Poll::Ready(_) => {
+                self.token = None;
+                true
+            }
+            Poll::Pending => false,
+        }
+    }
+}
+
+/// The caller's end of an in-process lane.
+pub struct LocalClientLane<P: Protocol> {
+    tx: mpsc::Sender<Frame<P::Request>>,
+    rx: mpsc::Receiver<Frame<P::Response>>,
+    order: LaneOrder,
+    lifetime: LaneLifetime,
+    _p: PhantomData<fn() -> P>,
+}
+
+impl<P: Protocol> LocalClientLane<P> {
+    /// A handle for writing to this lane from several tasks at once.
+    ///
+    /// r[impl jetstream.session.local.order-handoff]
+    /// The lane's own `Sink` is sequential and needs no help. Concurrent
+    /// producers do: use one or the other on a given lane, not both.
+    pub fn ordered_sender(&self) -> OrderedSender<P> {
+        OrderedSender {
+            tx: Arc::new(Mutex::new(self.tx.clone())),
+            order: self.order.clone(),
+        }
+    }
+}
+
+/// Writes frames to one lane in the order their tickets were taken.
+///
+/// r[impl jetstream.session.local.order-handoff]
+/// Take the ticket with [`OrderedSender::admit`] where the order is
+/// decided — before spawning, not inside the spawned task — then hand it
+/// to [`OrderedSender::deliver`]. A ticket dropped without delivering
+/// passes its place on rather than releasing it.
+pub struct OrderedSender<P: Protocol> {
+    tx: Arc<Mutex<mpsc::Sender<Frame<P::Request>>>>,
+    order: LaneOrder,
+}
+
+impl<P: Protocol> Clone for OrderedSender<P> {
+    fn clone(&self) -> Self {
+        Self {
+            tx: self.tx.clone(),
+            order: self.order.clone(),
+        }
+    }
+}
+
+impl<P: Protocol> OrderedSender<P> {
+    /// Take this frame's place in the lane's delivery order.
+    pub fn admit(&self) -> OrderTicket {
+        self.order.ticket()
+    }
+
+    /// Deliver `frame` when its ticket's turn comes.
+    pub async fn deliver(
+        &self,
+        ticket: OrderTicket,
+        frame: Frame<P::Request>,
+    ) -> Result<(), SessionError> {
+        ticket.wait().await;
+        let result = {
+            let mut tx = self.tx.lock().await;
+            tx.send(frame).await
+        };
+        ticket.complete();
+        result.map_err(|_| SessionError::LaneClosed)
+    }
+
+    /// Admit and deliver in one step, for a caller that is not handing
+    /// the frame to another task.
+    pub async fn send(
+        &self,
+        frame: Frame<P::Request>,
+    ) -> Result<(), SessionError> {
+        let ticket = self.admit();
+        self.deliver(ticket, frame).await
+    }
+}
+
+impl<P: Protocol> Sink<Frame<P::Request>> for LocalClientLane<P> {
+    type Error = Error;
+
+    fn poll_ready(
+        self: Pin<&mut Self>,
+        cx: &mut TaskContext<'_>,
+    ) -> Poll<Result<(), Self::Error>> {
+        let this = self.get_mut();
+        if this.lifetime.poll_closed(cx) {
+            return Poll::Ready(Err(SessionError::Closed.into()));
+        }
+        Pin::new(&mut this.tx)
+            .poll_ready(cx)
+            .map_err(|_| SessionError::LaneClosed.into())
+    }
+
+    fn start_send(
+        self: Pin<&mut Self>,
+        item: Frame<P::Request>,
+    ) -> Result<(), Self::Error> {
+        Pin::new(&mut self.get_mut().tx)
+            .start_send(item)
+            .map_err(|_| SessionError::LaneClosed.into())
+    }
+
+    fn poll_flush(
+        self: Pin<&mut Self>,
+        cx: &mut TaskContext<'_>,
+    ) -> Poll<Result<(), Self::Error>> {
+        Pin::new(&mut self.get_mut().tx)
+            .poll_flush(cx)
+            .map_err(|_| SessionError::LaneClosed.into())
+    }
+
+    fn poll_close(
+        self: Pin<&mut Self>,
+        cx: &mut TaskContext<'_>,
+    ) -> Poll<Result<(), Self::Error>> {
+        Pin::new(&mut self.get_mut().tx)
+            .poll_close(cx)
+            .map_err(|_| SessionError::LaneClosed.into())
+    }
+}
+
+impl<P: Protocol> Stream for LocalClientLane<P> {
+    type Item = Result<Frame<P::Response>, Error>;
+
+    fn poll_next(
+        self: Pin<&mut Self>,
+        cx: &mut TaskContext<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+        if this.lifetime.poll_closed(cx) {
+            if this.lifetime.reported {
+                return Poll::Ready(None);
+            }
+            this.lifetime.reported = true;
+            return Poll::Ready(Some(Err(SessionError::Closed.into())));
+        }
+        Pin::new(&mut this.rx).poll_next(cx).map(|f| f.map(Ok))
+    }
+}
+
+/// The callee's end of an in-process lane.
+pub struct LocalServiceLane<P: Protocol> {
+    tx: mpsc::Sender<Frame<P::Response>>,
+    rx: mpsc::Receiver<Frame<P::Request>>,
+    lifetime: LaneLifetime,
+    _p: PhantomData<fn() -> P>,
+}
+
+impl<P: Protocol> Sink<Frame<P::Response>> for LocalServiceLane<P> {
+    type Error = Error;
+
+    fn poll_ready(
+        self: Pin<&mut Self>,
+        cx: &mut TaskContext<'_>,
+    ) -> Poll<Result<(), Self::Error>> {
+        let this = self.get_mut();
+        if this.lifetime.poll_closed(cx) {
+            return Poll::Ready(Err(SessionError::Closed.into()));
+        }
+        Pin::new(&mut this.tx)
+            .poll_ready(cx)
+            .map_err(|_| SessionError::LaneClosed.into())
+    }
+
+    fn start_send(
+        self: Pin<&mut Self>,
+        item: Frame<P::Response>,
+    ) -> Result<(), Self::Error> {
+        Pin::new(&mut self.get_mut().tx)
+            .start_send(item)
+            .map_err(|_| SessionError::LaneClosed.into())
+    }
+
+    fn poll_flush(
+        self: Pin<&mut Self>,
+        cx: &mut TaskContext<'_>,
+    ) -> Poll<Result<(), Self::Error>> {
+        Pin::new(&mut self.get_mut().tx)
+            .poll_flush(cx)
+            .map_err(|_| SessionError::LaneClosed.into())
+    }
+
+    fn poll_close(
+        self: Pin<&mut Self>,
+        cx: &mut TaskContext<'_>,
+    ) -> Poll<Result<(), Self::Error>> {
+        Pin::new(&mut self.get_mut().tx)
+            .poll_close(cx)
+            .map_err(|_| SessionError::LaneClosed.into())
+    }
+}
+
+impl<P: Protocol> Stream for LocalServiceLane<P> {
+    type Item = Result<Frame<P::Request>, Error>;
+
+    fn poll_next(
+        self: Pin<&mut Self>,
+        cx: &mut TaskContext<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+        if this.lifetime.poll_closed(cx) {
+            if this.lifetime.reported {
+                return Poll::Ready(None);
+            }
+            this.lifetime.reported = true;
+            return Poll::Ready(Some(Err(SessionError::Closed.into())));
+        }
+        Pin::new(&mut this.rx).poll_next(cx).map(|f| f.map(Ok))
+    }
+}
+
+/// r[impl jetstream.session.local]
+/// An in-process session authenticates nothing, so the callee sees an
+/// empty context rather than a fabricated identity.
+impl<P: Protocol> Contextual for LocalServiceLane<P> {
+    fn context(&self) -> Context {
+        Context::default()
+    }
+}

--- a/components/jetstream_rpc/src/session/mod.rs
+++ b/components/jetstream_rpc/src/session/mod.rs
@@ -106,13 +106,12 @@ pub trait Session<P: Protocol>: Send + Sync {
 ///
 /// r[impl jetstream.session.symmetric]
 /// The channel belongs to the connection, so both directions exist at
-/// both ends and the methods name the direction rather than assuming
-/// one. A session is not fixed to a role — the peer that opens a lane
-/// is the caller *on that lane* — so a datagram API that only sent
+/// both ends. A session is not fixed to a role — the peer that opens a
+/// lane is the caller *on that lane* — so a datagram API that only sent
 /// requests and only received responses was wrong at whichever end was
-/// serving: a callee decoded its peer's requests as responses, which
-/// for any protocol whose two message types differ means rejecting or
-/// misreading every datagram it receives.
+/// serving: a callee encoded its answers as questions, and decoded its
+/// peer's questions as answers. Sending therefore names the direction.
+/// Receiving cannot, and does not: see `recv_datagram_bytes`.
 #[async_trait::async_trait]
 pub trait Datagrams<P: Protocol>: Send + Sync
 where
@@ -133,7 +132,24 @@ where
         bytes: Bytes,
     ) -> Result<(), SessionError>;
 
-    /// Receive the bytes of the next datagram that arrived intact.
+    /// Receive the next datagram that arrived intact.
+    ///
+    /// r[impl jetstream.session.datagrams]
+    /// Receiving is deliberately untyped, and deliberately singular.
+    /// The channel is one unordered queue belonging to the connection,
+    /// so every reader competes for the same packets — a typed
+    /// `recv_request` and a typed `recv_response` used at once would
+    /// each take datagrams meant for the other, fail to decode them,
+    /// and discard them for good. Nothing in a datagram says which
+    /// direction it is; the frame's message type does, but only a
+    /// protocol that partitions the type space can be read that way,
+    /// and `Protocol` does not require it.
+    ///
+    /// So a session hands out the bytes and the caller says what it
+    /// expects, with [`decode_datagram`]. A peer that receives in one
+    /// role — which is the usual case — writes one turbofish. A peer
+    /// that receives in both needs a discriminator of its own, and the
+    /// API says so by not pretending otherwise.
     async fn recv_datagram_bytes(&self) -> Result<Bytes, SessionError>;
 
     /// Send a request, as the caller.
@@ -148,13 +164,6 @@ where
         .await
     }
 
-    /// Receive the next request, as the callee.
-    async fn recv_request_datagram(
-        &self,
-    ) -> Result<Frame<P::Request>, SessionError> {
-        decode_datagram(self.recv_datagram_bytes().await?)
-    }
-
     /// Send a response, as the callee.
     async fn send_response_datagram(
         &self,
@@ -165,13 +174,6 @@ where
             self.max_datagram_size(),
         )?)
         .await
-    }
-
-    /// Receive the next response, as the caller.
-    async fn recv_response_datagram(
-        &self,
-    ) -> Result<Frame<P::Response>, SessionError> {
-        decode_datagram(self.recv_datagram_bytes().await?)
     }
 }
 

--- a/components/jetstream_rpc/src/session/mod.rs
+++ b/components/jetstream_rpc/src/session/mod.rs
@@ -16,6 +16,7 @@
 
 mod capabilities;
 mod error;
+pub mod lifetime;
 pub mod local;
 mod order;
 mod single;
@@ -28,6 +29,7 @@ use jetstream_wireformat::WireFormat;
 pub use self::{
     capabilities::{Capabilities, Capability, IdentityKind, LaneSupport},
     error::SessionError,
+    lifetime::LaneGuard,
     local::{LocalSession, LocalSessionPair},
     order::{LaneOrder, OrderTicket},
     single::{NoClientLane, NoServiceLane, SingleLaneSession},

--- a/components/jetstream_rpc/src/session/mod.rs
+++ b/components/jetstream_rpc/src/session/mod.rs
@@ -24,6 +24,7 @@ mod single;
 #[cfg(test)]
 mod tests;
 
+use bytes::Bytes;
 use jetstream_wireformat::WireFormat;
 
 pub use self::{
@@ -35,8 +36,8 @@ pub use self::{
     single::{NoClientLane, NoServiceLane, SingleLaneSession},
 };
 use crate::{
-    client::ClientTransport, context::Context, server::ServiceTransport, Frame,
-    Framer, Protocol,
+    client::ClientTransport, context::Context, server::ServiceTransport, Error,
+    Frame, Framer, Protocol,
 };
 
 /// An association with a peer, from which lanes are obtained.
@@ -94,19 +95,84 @@ pub trait Session<P: Protocol>: Send + Sync {
 /// r[impl jetstream.session.datagrams.not-a-lane]
 /// This is deliberately not a [`ClientTransport`]: a datagram channel is
 /// not a lane, and none of the lane ordering requirements apply to it.
+///
+/// A transport implements the three raw methods; the four framed ones
+/// are provided. That is deliberate. Every framed method has to check
+/// the path limit before sending and reject a datagram carrying
+/// anything after its frame, and when each transport wrote those out
+/// itself the two implementations drifted — iroh rejected trailing
+/// bytes and QUIC accepted them. Encoding and decoding belong to the
+/// model, not to the transport.
+///
+/// r[impl jetstream.session.symmetric]
+/// The channel belongs to the connection, so both directions exist at
+/// both ends and the methods name the direction rather than assuming
+/// one. A session is not fixed to a role — the peer that opens a lane
+/// is the caller *on that lane* — so a datagram API that only sent
+/// requests and only received responses was wrong at whichever end was
+/// serving: a callee decoded its peer's requests as responses, which
+/// for any protocol whose two message types differ means rejecting or
+/// misreading every datagram it receives.
 #[async_trait::async_trait]
-pub trait Datagrams<P: Protocol>: Send + Sync {
+pub trait Datagrams<P: Protocol>: Send + Sync
+where
+    // The framed methods are provided rather than required, so their
+    // bodies own a frame across an await and need the message types to
+    // outlive it. Every real protocol's messages are owned values, so
+    // this costs nothing but has to be said.
+    P::Request: 'static,
+    P::Response: 'static,
+{
     /// The largest frame the path will carry, if the transport knows it.
     fn max_datagram_size(&self) -> Option<u32>;
 
-    /// Send one frame, or fail. Never fragmented, never retried.
-    async fn send_datagram(
+    /// Send one already-encoded datagram, or fail. Never fragmented,
+    /// never retried.
+    async fn send_datagram_bytes(
         &self,
-        frame: Frame<P::Request>,
+        bytes: Bytes,
     ) -> Result<(), SessionError>;
 
-    /// Receive the next frame that arrived intact.
-    async fn recv_datagram(&self) -> Result<Frame<P::Response>, SessionError>;
+    /// Receive the bytes of the next datagram that arrived intact.
+    async fn recv_datagram_bytes(&self) -> Result<Bytes, SessionError>;
+
+    /// Send a request, as the caller.
+    async fn send_request_datagram(
+        &self,
+        frame: Frame<P::Request>,
+    ) -> Result<(), SessionError> {
+        self.send_datagram_bytes(encode_datagram(
+            &frame,
+            self.max_datagram_size(),
+        )?)
+        .await
+    }
+
+    /// Receive the next request, as the callee.
+    async fn recv_request_datagram(
+        &self,
+    ) -> Result<Frame<P::Request>, SessionError> {
+        decode_datagram(self.recv_datagram_bytes().await?)
+    }
+
+    /// Send a response, as the callee.
+    async fn send_response_datagram(
+        &self,
+        frame: Frame<P::Response>,
+    ) -> Result<(), SessionError> {
+        self.send_datagram_bytes(encode_datagram(
+            &frame,
+            self.max_datagram_size(),
+        )?)
+        .await
+    }
+
+    /// Receive the next response, as the caller.
+    async fn recv_response_datagram(
+        &self,
+    ) -> Result<Frame<P::Response>, SessionError> {
+        decode_datagram(self.recv_datagram_bytes().await?)
+    }
 }
 
 /// r[impl jetstream.session.datagrams]
@@ -125,4 +191,42 @@ pub fn check_datagram_size<T: Framer>(
         return Err(SessionError::DatagramTooLarge { size, limit });
     }
     Ok(())
+}
+
+/// r[impl jetstream.session.datagrams]
+/// Encode a frame for the datagram channel, refusing one the path
+/// cannot carry.
+pub fn encode_datagram<T: Framer>(
+    frame: &Frame<T>,
+    limit: Option<u32>,
+) -> Result<Bytes, SessionError> {
+    check_datagram_size(frame, limit)?;
+
+    let mut buf = Vec::with_capacity(WireFormat::byte_size(frame) as usize);
+    WireFormat::encode(frame, &mut buf)
+        .map_err(|err| SessionError::Transport(Error::from(err)))?;
+    Ok(Bytes::from(buf))
+}
+
+/// r[impl jetstream.session.datagrams]
+/// Decode one datagram, which carries a complete frame or is discarded.
+/// There is nothing to reassemble it from, so bytes after the frame mean
+/// it is not a complete frame either: decoding would succeed on the
+/// prefix and hand back something the peer never sent.
+pub fn decode_datagram<T: Framer>(
+    datagram: Bytes,
+) -> Result<Frame<T>, SessionError> {
+    let mut reader = std::io::Cursor::new(datagram.as_ref());
+    let frame = <Frame<T> as WireFormat>::decode(&mut reader)
+        .map_err(|err| SessionError::Transport(Error::from(err)))?;
+
+    let consumed = reader.position() as usize;
+    if consumed != datagram.len() {
+        return Err(SessionError::Transport(Error::new(format!(
+            "datagram has {} trailing bytes after the frame",
+            datagram.len() - consumed
+        ))));
+    }
+
+    Ok(frame)
 }

--- a/components/jetstream_rpc/src/session/mod.rs
+++ b/components/jetstream_rpc/src/session/mod.rs
@@ -1,0 +1,126 @@
+//! Sessions and lanes.
+//!
+//! r[impl jetstream.session.overview]
+//! A **session** is the association with a peer: it carries identity and
+//! capabilities and can open and accept lanes. A **lane** is one
+//! ordered, reliable, flow-controlled sequence of frames — exactly what
+//! [`ClientTransport`] describes from one end and [`ServiceTransport`]
+//! from the other. A session orders nothing; ordering is a property of a
+//! lane and only of a lane.
+//!
+//! r[impl jetstream.session.overview.additive]
+//! Nothing here changes the [`ClientTransport`] or [`ServiceTransport`]
+//! bounds. A lane *is* a value satisfying them; what a session adds is a
+//! way to obtain one without naming the concrete transport. Code that
+//! holds a single transport and multiplexes by tag keeps working.
+
+mod capabilities;
+mod error;
+pub mod local;
+mod order;
+mod single;
+
+#[cfg(test)]
+mod tests;
+
+use jetstream_wireformat::WireFormat;
+
+pub use self::{
+    capabilities::{Capabilities, Capability, IdentityKind, LaneSupport},
+    error::SessionError,
+    local::{LocalSession, LocalSessionPair},
+    order::{LaneOrder, OrderTicket},
+    single::{NoClientLane, NoServiceLane, SingleLaneSession},
+};
+use crate::{
+    client::ClientTransport, context::Context, server::ServiceTransport, Frame,
+    Framer, Protocol,
+};
+
+/// An association with a peer, from which lanes are obtained.
+///
+/// r[impl jetstream.session.trait]
+/// Opening and accepting are fallible and asynchronous, and both take
+/// `&self`: a session is usable from several tasks at once, and opening
+/// a lane never requires exclusive access to the session.
+///
+/// r[impl jetstream.session.symmetric]
+/// Where the transport is symmetric either peer may open a lane, and the
+/// opener is the RPC caller on it. That is why the two directions have
+/// different lane types: [`Session::open_lane`] yields the caller's end,
+/// [`Session::accept_lane`] the callee's.
+#[async_trait::async_trait]
+pub trait Session<P: Protocol>: Send + Sync {
+    /// The end of a lane this peer opened, driven as the RPC caller.
+    type ClientLane: ClientTransport<P>;
+    /// The end of a lane the peer opened, served as the RPC callee.
+    type ServiceLane: ServiceTransport<P>;
+
+    /// What this session can do.
+    ///
+    /// r[impl jetstream.session.capabilities]
+    fn capabilities(&self) -> Capabilities;
+
+    /// The peer's identity, in the form the transport established it.
+    ///
+    /// r[impl jetstream.session.identity]
+    fn context(&self) -> Context {
+        Context::default()
+    }
+
+    /// Open a new lane and take the caller's end of it.
+    async fn open_lane(&self) -> Result<Self::ClientLane, SessionError>;
+
+    /// Wait for the peer to open a lane and take the callee's end of it.
+    async fn accept_lane(&self) -> Result<Self::ServiceLane, SessionError>;
+
+    /// Close the session.
+    ///
+    /// r[impl jetstream.session.lifetime]
+    /// Every lane opened on the session terminates, and calls in flight
+    /// on those lanes fail rather than hang. Closing a lane does not
+    /// close its session.
+    async fn close(&self);
+}
+
+/// The optional unordered channel belonging to a session.
+///
+/// r[impl jetstream.session.datagrams]
+/// Datagrams may be dropped, may arrive in any order, and are never
+/// retransmitted by JetStream.
+///
+/// r[impl jetstream.session.datagrams.not-a-lane]
+/// This is deliberately not a [`ClientTransport`]: a datagram channel is
+/// not a lane, and none of the lane ordering requirements apply to it.
+#[async_trait::async_trait]
+pub trait Datagrams<P: Protocol>: Send + Sync {
+    /// The largest frame the path will carry, if the transport knows it.
+    fn max_datagram_size(&self) -> Option<u32>;
+
+    /// Send one frame, or fail. Never fragmented, never retried.
+    async fn send_datagram(
+        &self,
+        frame: Frame<P::Request>,
+    ) -> Result<(), SessionError>;
+
+    /// Receive the next frame that arrived intact.
+    async fn recv_datagram(&self) -> Result<Frame<P::Response>, SessionError>;
+}
+
+/// r[impl jetstream.session.datagrams]
+/// Reject an oversized frame at the send site, which is the only place
+/// that can report it: a frame that exceeds the path limit is not
+/// fragmented, so there is nothing further down to notice.
+pub fn check_datagram_size<T: Framer>(
+    frame: &Frame<T>,
+    limit: Option<u32>,
+) -> Result<(), SessionError> {
+    let Some(limit) = limit else {
+        return Ok(());
+    };
+    let size = WireFormat::byte_size(frame);
+    if size > limit {
+        return Err(SessionError::DatagramTooLarge { size, limit });
+    }
+    Ok(())
+}

--- a/components/jetstream_rpc/src/session/order.rs
+++ b/components/jetstream_rpc/src/session/order.rs
@@ -1,0 +1,150 @@
+//! Delivery order taken at the call site.
+//!
+//! r[impl jetstream.session.local.order-handoff]
+//! A lane whose delivery is admitted asynchronously cannot take its
+//! order from the order in which admission completes: two tasks that
+//! were handed frames in a known order will finish acquiring the send
+//! half in an arbitrary one. [`LaneOrder`] hands out a ticket
+//! synchronously, at the point where the order is decided, and delivery
+//! waits for its ticket's turn.
+//!
+//! A ticket that is dropped without delivering passes its place to the
+//! next frame on the lane rather than releasing it, so a frame that is
+//! abandoned mid-flight cannot let a later frame overtake an earlier one
+//! that is still in flight.
+
+use std::{
+    collections::BTreeSet,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc, Mutex,
+    },
+};
+
+use tokio::sync::Notify;
+
+#[derive(Debug, Default)]
+struct OrderState {
+    /// The ticket whose turn it is.
+    turn: u64,
+    /// Tickets dropped before their turn arrived. Skipped when reached.
+    abandoned: BTreeSet<u64>,
+}
+
+#[derive(Debug, Default)]
+struct OrderInner {
+    next: AtomicU64,
+    state: Mutex<OrderState>,
+    notify: Notify,
+}
+
+impl OrderInner {
+    /// Move past `seq`, skipping any ticket abandoned in the meantime.
+    fn advance_locked(state: &mut OrderState, seq: u64) {
+        let mut turn = seq + 1;
+        while state.abandoned.remove(&turn) {
+            turn += 1;
+        }
+        state.turn = turn;
+    }
+
+    fn release(&self, seq: u64) {
+        let mut state = self.state.lock().expect("lane order poisoned");
+        if state.turn == seq {
+            Self::advance_locked(&mut state, seq);
+            drop(state);
+            self.notify.notify_waiters();
+        } else {
+            // Not our turn yet: mark the slot so that whoever reaches it
+            // skips straight over us.
+            state.abandoned.insert(seq);
+        }
+    }
+}
+
+/// Hands out delivery order for one lane.
+///
+/// Cheap to clone; every clone shares one order.
+#[derive(Debug, Clone, Default)]
+pub struct LaneOrder {
+    inner: Arc<OrderInner>,
+}
+
+impl LaneOrder {
+    /// A fresh order, starting at ticket zero.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Take the next place in line.
+    ///
+    /// This is deliberately synchronous: it must run where the order is
+    /// decided, not inside the task that later performs the delivery.
+    pub fn ticket(&self) -> OrderTicket {
+        let seq = self.inner.next.fetch_add(1, Ordering::SeqCst);
+        OrderTicket {
+            seq,
+            inner: self.inner.clone(),
+            done: false,
+        }
+    }
+
+    /// The ticket whose turn it currently is.
+    pub fn turn(&self) -> u64 {
+        self.inner.state.lock().expect("lane order poisoned").turn
+    }
+}
+
+/// One frame's place in a lane's delivery order.
+///
+/// Dropping a ticket without calling [`OrderTicket::complete`] hands its
+/// place to the next frame on the lane.
+#[derive(Debug)]
+pub struct OrderTicket {
+    seq: u64,
+    inner: Arc<OrderInner>,
+    done: bool,
+}
+
+impl OrderTicket {
+    /// This ticket's position in the order.
+    pub fn seq(&self) -> u64 {
+        self.seq
+    }
+
+    /// Wait until it is this ticket's turn to deliver.
+    pub async fn wait(&self) {
+        loop {
+            let notified = self.inner.notify.notified();
+            tokio::pin!(notified);
+            // Register before checking, so a release between the check
+            // and the await cannot be missed.
+            notified.as_mut().enable();
+
+            {
+                let state =
+                    self.inner.state.lock().expect("lane order poisoned");
+                if state.turn == self.seq {
+                    return;
+                }
+            }
+
+            notified.await;
+        }
+    }
+
+    /// Record that this ticket's frame has been delivered and let the
+    /// next one go.
+    pub fn complete(mut self) {
+        self.done = true;
+        self.inner.release(self.seq);
+    }
+}
+
+impl Drop for OrderTicket {
+    fn drop(&mut self) {
+        if !self.done {
+            self.inner.release(self.seq);
+        }
+    }
+}

--- a/components/jetstream_rpc/src/session/order.rs
+++ b/components/jetstream_rpc/src/session/order.rs
@@ -76,6 +76,19 @@ impl LaneOrder {
         Self::default()
     }
 
+    /// Whether this order issued `ticket`.
+    ///
+    /// r[impl jetstream.session.local.order-handoff]
+    /// A ticket names a place in *one* lane's order. Every lane's
+    /// `admit` returns the same type, so nothing but this stops a
+    /// caller holding senders for two lanes from handing one lane's
+    /// ticket to the other — which would wait on the wrong sequence and
+    /// write to the wrong lane, either stalling behind a place it does
+    /// not hold or overtaking one it should have waited for.
+    pub fn issued(&self, ticket: &OrderTicket) -> bool {
+        Arc::ptr_eq(&self.inner, &ticket.inner)
+    }
+
     /// Take the next place in line.
     ///
     /// This is deliberately synchronous: it must run where the order is

--- a/components/jetstream_rpc/src/session/single.rs
+++ b/components/jetstream_rpc/src/session/single.rs
@@ -12,15 +12,13 @@ use std::{
     fmt,
     marker::PhantomData,
     pin::Pin,
-    sync::{
-        atomic::{AtomicBool, Ordering},
-        Mutex as StdMutex,
-    },
+    sync::{atomic::AtomicUsize, Arc},
     task::{Context as TaskContext, Poll},
 };
 
-use futures::{channel::oneshot, Sink, Stream};
+use futures::{Sink, Stream};
 use tokio::sync::Mutex;
+use tokio_util::sync::CancellationToken;
 
 use crate::{
     client::ClientTransport,
@@ -29,7 +27,7 @@ use crate::{
     session::{
         capabilities::{Capabilities, IdentityKind, LaneSupport},
         error::SessionError,
-        lifetime::LaneGuard,
+        lifetime::{LaneGuard, LaneLifetime},
         Session,
     },
     Error, Frame, Protocol,
@@ -177,14 +175,16 @@ pub struct SingleLaneSession<P: Protocol, C, S> {
     client: Mutex<Option<C>>,
     service: Mutex<Option<S>>,
     /// r[impl jetstream.session.lifetime]
-    /// The token half for the lane once it has been handed out. Held by
-    /// the session so that `close` reaches a lane the caller owns.
-    tokens: StdMutex<Vec<oneshot::Sender<()>>>,
-    closed: AtomicBool,
+    /// Cancelled by `close`. Every lane holds a child of it, so closing
+    /// reaches a lane the caller already owns.
+    cancel: CancellationToken,
+    live: Arc<AtomicUsize>,
     opens: bool,
     accepts: bool,
     identity: IdentityKind,
-    context: Context,
+    /// The identity the session established, where the lane underneath
+    /// does not know it. `None` leaves the lane's own context alone.
+    context: Option<Context>,
     _p: PhantomData<fn() -> P>,
 }
 
@@ -194,12 +194,12 @@ impl<P: Protocol, C> SingleLaneSession<P, C, NoServiceLane<P>> {
         Self {
             client: Mutex::new(Some(lane)),
             service: Mutex::new(None),
-            tokens: StdMutex::new(Vec::new()),
-            closed: AtomicBool::new(false),
+            cancel: CancellationToken::new(),
+            live: Arc::new(AtomicUsize::new(0)),
             opens: true,
             accepts: false,
             identity: IdentityKind::None,
-            context: Context::default(),
+            context: None,
             _p: PhantomData,
         }
     }
@@ -211,12 +211,12 @@ impl<P: Protocol, S> SingleLaneSession<P, NoClientLane<P>, S> {
         Self {
             client: Mutex::new(None),
             service: Mutex::new(Some(lane)),
-            tokens: StdMutex::new(Vec::new()),
-            closed: AtomicBool::new(false),
+            cancel: CancellationToken::new(),
+            live: Arc::new(AtomicUsize::new(0)),
             opens: false,
             accepts: true,
             identity: IdentityKind::None,
-            context: Context::default(),
+            context: None,
             _p: PhantomData,
         }
     }
@@ -224,18 +224,21 @@ impl<P: Protocol, S> SingleLaneSession<P, NoClientLane<P>, S> {
 
 impl<P: Protocol, C, S> SingleLaneSession<P, C, S> {
     fn is_closed(&self) -> bool {
-        self.closed.load(Ordering::SeqCst)
+        self.cancel.is_cancelled()
     }
 
     /// r[impl jetstream.session.lifetime]
-    /// Mint the token this session will drop on close.
-    fn token(&self) -> oneshot::Receiver<()> {
-        let (tx, rx) = oneshot::channel();
-        self.tokens
-            .lock()
-            .expect("session tokens poisoned")
-            .push(tx);
-        rx
+    /// A lane's share of this session's lifetime. Taking a child of an
+    /// already-cancelled token yields an already-cancelled child, so a
+    /// lane handed out concurrently with `close` is born terminated
+    /// rather than escaping it.
+    fn lifetime(&self) -> LaneLifetime {
+        LaneLifetime::new(self.cancel.child_token(), self.live.clone())
+    }
+
+    /// How many lanes this session is currently keeping alive.
+    pub fn live_lanes(&self) -> usize {
+        self.live.load(std::sync::atomic::Ordering::SeqCst)
     }
 
     /// Report a peer identity model other than
@@ -247,8 +250,13 @@ impl<P: Protocol, C, S> SingleLaneSession<P, C, S> {
     }
 
     /// Attach the peer identity the transport established.
+    ///
+    /// r[impl jetstream.session.identity]
+    /// A lane accepted from this session reports this identity rather
+    /// than whatever the framed stream underneath knows, so a TLS
+    /// adapter's authenticated peer reaches the handler.
     pub fn with_context(mut self, context: Context) -> Self {
-        self.context = context;
+        self.context = Some(context);
         self
     }
 }
@@ -275,7 +283,7 @@ where
     }
 
     fn context(&self) -> Context {
-        self.context.clone()
+        self.context.clone().unwrap_or_default()
     }
 
     async fn open_lane(&self) -> Result<Self::ClientLane, SessionError> {
@@ -287,7 +295,7 @@ where
         } else {
             SessionError::OpenUnsupported
         })?;
-        Ok(LaneGuard::new(lane, self.token()))
+        Ok(LaneGuard::new(lane, self.lifetime()))
     }
 
     async fn accept_lane(&self) -> Result<Self::ServiceLane, SessionError> {
@@ -299,17 +307,23 @@ where
         } else {
             SessionError::AcceptUnsupported
         })?;
-        Ok(LaneGuard::new(lane, self.token()))
+        // r[impl jetstream.session.identity]
+        // The handler sees the session's identity where there is one.
+        Ok(LaneGuard::with_context(
+            lane,
+            self.lifetime(),
+            self.context.clone(),
+        ))
     }
 
     /// r[impl jetstream.session.lifetime]
     /// Terminates the lane whether or not it has been handed out:
-    /// dropping the token reaches a lane the caller already owns, so a
-    /// call in flight on it fails rather than continuing to run on a
-    /// session that has closed.
+    /// cancelling reaches a lane the caller already owns, so a call in
+    /// flight on it fails rather than continuing to run on a session
+    /// that has closed. A lane handed out concurrently with this call is
+    /// born cancelled rather than escaping it.
     async fn close(&self) {
-        self.closed.store(true, Ordering::SeqCst);
-        self.tokens.lock().expect("session tokens poisoned").clear();
+        self.cancel.cancel();
         self.client.lock().await.take();
         self.service.lock().await.take();
     }

--- a/components/jetstream_rpc/src/session/single.rs
+++ b/components/jetstream_rpc/src/session/single.rs
@@ -1,0 +1,275 @@
+//! Presenting a plain byte stream as a session.
+//!
+//! r[impl jetstream.session.single-lane]
+//! r[impl jetstream.session.conformance.single-stream]
+//! TCP, TLS, unix sockets and stdio cannot open a second stream, but
+//! they are still sessions: one lane, obtained once. The second open
+//! fails with [`SessionError::LaneLimitReached`], which is distinct and
+//! inspectable, rather than blocking or handing back the lane that is
+//! already in use.
+
+use std::{
+    fmt,
+    marker::PhantomData,
+    pin::Pin,
+    task::{Context as TaskContext, Poll},
+};
+
+use futures::{Sink, Stream};
+use tokio::sync::Mutex;
+
+use crate::{
+    client::ClientTransport,
+    context::{Context, Contextual},
+    server::ServiceTransport,
+    session::{
+        capabilities::{Capabilities, IdentityKind, LaneSupport},
+        error::SessionError,
+        Session,
+    },
+    Error, Frame, Protocol,
+};
+
+enum Never {}
+
+impl<P: Protocol> fmt::Debug for NoClientLane<P> {
+    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        unreachable!("NoClientLane cannot be constructed")
+    }
+}
+
+impl<P: Protocol> fmt::Debug for NoServiceLane<P> {
+    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        unreachable!("NoServiceLane cannot be constructed")
+    }
+}
+
+impl<P: Protocol, C, S> fmt::Debug for SingleLaneSession<P, C, S> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SingleLaneSession")
+            .field("lanes", &LaneSupport::One)
+            .field("identity", &self.identity)
+            .finish_non_exhaustive()
+    }
+}
+
+/// The caller's end of a lane a session can never open.
+///
+/// Uninhabited: a session that names this as its
+/// [`Session::ClientLane`] is one whose `open_lane` always fails, and
+/// the type says so rather than a runtime convention saying it.
+pub struct NoClientLane<P: Protocol> {
+    _never: Never,
+    _p: PhantomData<fn() -> P>,
+}
+
+impl<P: Protocol> Sink<Frame<P::Request>> for NoClientLane<P> {
+    type Error = Error;
+
+    fn poll_ready(
+        self: Pin<&mut Self>,
+        _cx: &mut TaskContext<'_>,
+    ) -> Poll<Result<(), Self::Error>> {
+        unreachable!("NoClientLane cannot be constructed")
+    }
+
+    fn start_send(
+        self: Pin<&mut Self>,
+        _item: Frame<P::Request>,
+    ) -> Result<(), Self::Error> {
+        unreachable!("NoClientLane cannot be constructed")
+    }
+
+    fn poll_flush(
+        self: Pin<&mut Self>,
+        _cx: &mut TaskContext<'_>,
+    ) -> Poll<Result<(), Self::Error>> {
+        unreachable!("NoClientLane cannot be constructed")
+    }
+
+    fn poll_close(
+        self: Pin<&mut Self>,
+        _cx: &mut TaskContext<'_>,
+    ) -> Poll<Result<(), Self::Error>> {
+        unreachable!("NoClientLane cannot be constructed")
+    }
+}
+
+impl<P: Protocol> Stream for NoClientLane<P> {
+    type Item = Result<Frame<P::Response>, Error>;
+
+    fn poll_next(
+        self: Pin<&mut Self>,
+        _cx: &mut TaskContext<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        unreachable!("NoClientLane cannot be constructed")
+    }
+}
+
+/// The callee's end of a lane a session can never accept.
+///
+/// Uninhabited, for the same reason as [`NoClientLane`]: a client on a
+/// byte stream has nothing to accept.
+pub struct NoServiceLane<P: Protocol> {
+    _never: Never,
+    _p: PhantomData<fn() -> P>,
+}
+
+impl<P: Protocol> Sink<Frame<P::Response>> for NoServiceLane<P> {
+    type Error = P::Error;
+
+    fn poll_ready(
+        self: Pin<&mut Self>,
+        _cx: &mut TaskContext<'_>,
+    ) -> Poll<Result<(), Self::Error>> {
+        unreachable!("NoServiceLane cannot be constructed")
+    }
+
+    fn start_send(
+        self: Pin<&mut Self>,
+        _item: Frame<P::Response>,
+    ) -> Result<(), Self::Error> {
+        unreachable!("NoServiceLane cannot be constructed")
+    }
+
+    fn poll_flush(
+        self: Pin<&mut Self>,
+        _cx: &mut TaskContext<'_>,
+    ) -> Poll<Result<(), Self::Error>> {
+        unreachable!("NoServiceLane cannot be constructed")
+    }
+
+    fn poll_close(
+        self: Pin<&mut Self>,
+        _cx: &mut TaskContext<'_>,
+    ) -> Poll<Result<(), Self::Error>> {
+        unreachable!("NoServiceLane cannot be constructed")
+    }
+}
+
+impl<P: Protocol> Stream for NoServiceLane<P> {
+    type Item = Result<Frame<P::Request>, P::Error>;
+
+    fn poll_next(
+        self: Pin<&mut Self>,
+        _cx: &mut TaskContext<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        unreachable!("NoServiceLane cannot be constructed")
+    }
+}
+
+impl<P: Protocol> Contextual for NoServiceLane<P> {
+    fn context(&self) -> Context {
+        unreachable!("NoServiceLane cannot be constructed")
+    }
+}
+
+/// A session over a transport that carries exactly one lane.
+///
+/// Built from a lane that already exists — a framed TCP or unix stream —
+/// and hands it out once.
+pub struct SingleLaneSession<P: Protocol, C, S> {
+    client: Mutex<Option<C>>,
+    service: Mutex<Option<S>>,
+    opens: bool,
+    accepts: bool,
+    identity: IdentityKind,
+    context: Context,
+    _p: PhantomData<fn() -> P>,
+}
+
+impl<P: Protocol, C> SingleLaneSession<P, C, NoServiceLane<P>> {
+    /// Present `lane` as the one lane this peer may open.
+    pub fn client(lane: C) -> Self {
+        Self {
+            client: Mutex::new(Some(lane)),
+            service: Mutex::new(None),
+            opens: true,
+            accepts: false,
+            identity: IdentityKind::None,
+            context: Context::default(),
+            _p: PhantomData,
+        }
+    }
+}
+
+impl<P: Protocol, S> SingleLaneSession<P, NoClientLane<P>, S> {
+    /// Present `lane` as the one lane this peer may accept.
+    pub fn service(lane: S) -> Self {
+        Self {
+            client: Mutex::new(None),
+            service: Mutex::new(Some(lane)),
+            opens: false,
+            accepts: true,
+            identity: IdentityKind::None,
+            context: Context::default(),
+            _p: PhantomData,
+        }
+    }
+}
+
+impl<P: Protocol, C, S> SingleLaneSession<P, C, S> {
+    /// Report a peer identity model other than
+    /// [`IdentityKind::None`] — a TLS stream authenticates its peer even
+    /// though it carries one lane.
+    pub fn with_identity(mut self, identity: IdentityKind) -> Self {
+        self.identity = identity;
+        self
+    }
+
+    /// Attach the peer identity the transport established.
+    pub fn with_context(mut self, context: Context) -> Self {
+        self.context = context;
+        self
+    }
+}
+
+#[async_trait::async_trait]
+impl<P, C, S> Session<P> for SingleLaneSession<P, C, S>
+where
+    P: Protocol,
+    C: ClientTransport<P>,
+    S: ServiceTransport<P>,
+{
+    type ClientLane = C;
+    type ServiceLane = S;
+
+    fn capabilities(&self) -> Capabilities {
+        Capabilities {
+            lanes: LaneSupport::One,
+            datagrams: false,
+            identity: self.identity,
+            migration: false,
+        }
+    }
+
+    fn context(&self) -> Context {
+        self.context.clone()
+    }
+
+    async fn open_lane(&self) -> Result<Self::ClientLane, SessionError> {
+        self.client.lock().await.take().ok_or(if self.opens {
+            SessionError::LaneLimitReached
+        } else {
+            SessionError::OpenUnsupported
+        })
+    }
+
+    async fn accept_lane(&self) -> Result<Self::ServiceLane, SessionError> {
+        self.service.lock().await.take().ok_or(if self.accepts {
+            SessionError::LaneLimitReached
+        } else {
+            SessionError::AcceptUnsupported
+        })
+    }
+
+    /// Drops the lane if it has not been handed out yet.
+    ///
+    /// A byte-stream session *is* its lane: once the caller holds it,
+    /// closing the session is closing the lane, and the caller does that
+    /// by dropping what it holds.
+    async fn close(&self) {
+        self.client.lock().await.take();
+        self.service.lock().await.take();
+    }
+}

--- a/components/jetstream_rpc/src/session/single.rs
+++ b/components/jetstream_rpc/src/session/single.rs
@@ -300,7 +300,19 @@ where
         if self.is_closed() {
             return Err(SessionError::Closed);
         }
-        let lane = self.client.lock().await.take().ok_or(if self.opens {
+        let mut slot = self.client.lock().await;
+        // r[impl jetstream.session.lifetime]
+        // `close` cancels and then empties the slots, so a task that
+        // passed the check above and waited here finds an empty slot.
+        // Without this it would report `LaneLimitReached` — "you have
+        // already had your one lane" — for a session that closed, which
+        // is a different thing to tell a caller deciding whether to
+        // retry. The ordering in `close` is what makes this sound: the
+        // cancel is visible before the slot is empty.
+        if self.is_closed() {
+            return Err(SessionError::Closed);
+        }
+        let lane = slot.take().ok_or(if self.opens {
             SessionError::LaneLimitReached
         } else {
             SessionError::OpenUnsupported
@@ -312,7 +324,14 @@ where
         if self.is_closed() {
             return Err(SessionError::Closed);
         }
-        let lane = self.service.lock().await.take().ok_or(if self.accepts {
+        let mut slot = self.service.lock().await;
+        // r[impl jetstream.session.lifetime]
+        // As in `open_lane`: a waiter must not read an emptied slot as
+        // a limit when what happened was a close.
+        if self.is_closed() {
+            return Err(SessionError::Closed);
+        }
+        let lane = slot.take().ok_or(if self.accepts {
             SessionError::LaneLimitReached
         } else {
             SessionError::AcceptUnsupported

--- a/components/jetstream_rpc/src/session/single.rs
+++ b/components/jetstream_rpc/src/session/single.rs
@@ -12,10 +12,14 @@ use std::{
     fmt,
     marker::PhantomData,
     pin::Pin,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Mutex as StdMutex,
+    },
     task::{Context as TaskContext, Poll},
 };
 
-use futures::{Sink, Stream};
+use futures::{channel::oneshot, Sink, Stream};
 use tokio::sync::Mutex;
 
 use crate::{
@@ -25,6 +29,7 @@ use crate::{
     session::{
         capabilities::{Capabilities, IdentityKind, LaneSupport},
         error::SessionError,
+        lifetime::LaneGuard,
         Session,
     },
     Error, Frame, Protocol,
@@ -116,7 +121,7 @@ pub struct NoServiceLane<P: Protocol> {
 }
 
 impl<P: Protocol> Sink<Frame<P::Response>> for NoServiceLane<P> {
-    type Error = P::Error;
+    type Error = Error;
 
     fn poll_ready(
         self: Pin<&mut Self>,
@@ -148,7 +153,7 @@ impl<P: Protocol> Sink<Frame<P::Response>> for NoServiceLane<P> {
 }
 
 impl<P: Protocol> Stream for NoServiceLane<P> {
-    type Item = Result<Frame<P::Request>, P::Error>;
+    type Item = Result<Frame<P::Request>, Error>;
 
     fn poll_next(
         self: Pin<&mut Self>,
@@ -171,6 +176,11 @@ impl<P: Protocol> Contextual for NoServiceLane<P> {
 pub struct SingleLaneSession<P: Protocol, C, S> {
     client: Mutex<Option<C>>,
     service: Mutex<Option<S>>,
+    /// r[impl jetstream.session.lifetime]
+    /// The token half for the lane once it has been handed out. Held by
+    /// the session so that `close` reaches a lane the caller owns.
+    tokens: StdMutex<Vec<oneshot::Sender<()>>>,
+    closed: AtomicBool,
     opens: bool,
     accepts: bool,
     identity: IdentityKind,
@@ -184,6 +194,8 @@ impl<P: Protocol, C> SingleLaneSession<P, C, NoServiceLane<P>> {
         Self {
             client: Mutex::new(Some(lane)),
             service: Mutex::new(None),
+            tokens: StdMutex::new(Vec::new()),
+            closed: AtomicBool::new(false),
             opens: true,
             accepts: false,
             identity: IdentityKind::None,
@@ -199,6 +211,8 @@ impl<P: Protocol, S> SingleLaneSession<P, NoClientLane<P>, S> {
         Self {
             client: Mutex::new(None),
             service: Mutex::new(Some(lane)),
+            tokens: StdMutex::new(Vec::new()),
+            closed: AtomicBool::new(false),
             opens: false,
             accepts: true,
             identity: IdentityKind::None,
@@ -209,6 +223,21 @@ impl<P: Protocol, S> SingleLaneSession<P, NoClientLane<P>, S> {
 }
 
 impl<P: Protocol, C, S> SingleLaneSession<P, C, S> {
+    fn is_closed(&self) -> bool {
+        self.closed.load(Ordering::SeqCst)
+    }
+
+    /// r[impl jetstream.session.lifetime]
+    /// Mint the token this session will drop on close.
+    fn token(&self) -> oneshot::Receiver<()> {
+        let (tx, rx) = oneshot::channel();
+        self.tokens
+            .lock()
+            .expect("session tokens poisoned")
+            .push(tx);
+        rx
+    }
+
     /// Report a peer identity model other than
     /// [`IdentityKind::None`] — a TLS stream authenticates its peer even
     /// though it carries one lane.
@@ -227,12 +256,14 @@ impl<P: Protocol, C, S> SingleLaneSession<P, C, S> {
 #[async_trait::async_trait]
 impl<P, C, S> Session<P> for SingleLaneSession<P, C, S>
 where
-    P: Protocol,
+    P: Protocol<Error = Error>,
     C: ClientTransport<P>,
-    S: ServiceTransport<P>,
+    // `Contextual` is what the blanket `ServiceTransport` impl is built
+    // on; naming it here lets the guard forward the peer identity.
+    S: ServiceTransport<P> + Contextual,
 {
-    type ClientLane = C;
-    type ServiceLane = S;
+    type ClientLane = LaneGuard<C>;
+    type ServiceLane = LaneGuard<S>;
 
     fn capabilities(&self) -> Capabilities {
         Capabilities {
@@ -248,27 +279,37 @@ where
     }
 
     async fn open_lane(&self) -> Result<Self::ClientLane, SessionError> {
-        self.client.lock().await.take().ok_or(if self.opens {
+        if self.is_closed() {
+            return Err(SessionError::Closed);
+        }
+        let lane = self.client.lock().await.take().ok_or(if self.opens {
             SessionError::LaneLimitReached
         } else {
             SessionError::OpenUnsupported
-        })
+        })?;
+        Ok(LaneGuard::new(lane, self.token()))
     }
 
     async fn accept_lane(&self) -> Result<Self::ServiceLane, SessionError> {
-        self.service.lock().await.take().ok_or(if self.accepts {
+        if self.is_closed() {
+            return Err(SessionError::Closed);
+        }
+        let lane = self.service.lock().await.take().ok_or(if self.accepts {
             SessionError::LaneLimitReached
         } else {
             SessionError::AcceptUnsupported
-        })
+        })?;
+        Ok(LaneGuard::new(lane, self.token()))
     }
 
-    /// Drops the lane if it has not been handed out yet.
-    ///
-    /// A byte-stream session *is* its lane: once the caller holds it,
-    /// closing the session is closing the lane, and the caller does that
-    /// by dropping what it holds.
+    /// r[impl jetstream.session.lifetime]
+    /// Terminates the lane whether or not it has been handed out:
+    /// dropping the token reaches a lane the caller already owns, so a
+    /// call in flight on it fails rather than continuing to run on a
+    /// session that has closed.
     async fn close(&self) {
+        self.closed.store(true, Ordering::SeqCst);
+        self.tokens.lock().expect("session tokens poisoned").clear();
         self.client.lock().await.take();
         self.service.lock().await.take();
     }

--- a/components/jetstream_rpc/src/session/single.rs
+++ b/components/jetstream_rpc/src/session/single.rs
@@ -261,6 +261,16 @@ impl<P: Protocol, C, S> SingleLaneSession<P, C, S> {
     }
 }
 
+/// r[impl jetstream.session.lifetime]
+/// A lane must not outlive its session, so a session that goes away
+/// without `close` — dropped during error unwinding, say — terminates
+/// its lane just the same.
+impl<P: Protocol, C, S> Drop for SingleLaneSession<P, C, S> {
+    fn drop(&mut self) {
+        self.cancel.cancel();
+    }
+}
+
 #[async_trait::async_trait]
 impl<P, C, S> Session<P> for SingleLaneSession<P, C, S>
 where

--- a/components/jetstream_rpc/src/session/tests.rs
+++ b/components/jetstream_rpc/src/session/tests.rs
@@ -872,3 +872,71 @@ async fn dropping_a_single_lane_session_terminates_its_lane() {
         .expect_err("as an error");
     assert_eq!(err.code(), Some("jetstream::session::closed"));
 }
+
+// Regression: `LaneGuard::start_send` forwarded unconditionally. The
+// round-three patch that was meant to add this check silently failed to
+// apply — the two lane sinks got it, the guard did not, and the reply
+// claiming otherwise was wrong.
+// r[impl jetstream.session.lifetime]
+#[tokio::test]
+async fn a_guarded_write_committed_after_close_fails() {
+    use futures::Sink;
+
+    let pair = LocalSession::<TestProtocol>::pair();
+    let inner = pair.client.open_lane().await.unwrap();
+    let session = SingleLaneSession::<TestProtocol, _, _>::client(inner);
+    let mut lane = session.open_lane().await.unwrap();
+
+    futures::future::poll_fn(|cx| {
+        Sink::<Frame<Ping>>::poll_ready(Pin::new(&mut lane), cx)
+    })
+    .await
+    .unwrap();
+
+    session.close().await;
+
+    assert!(
+        Sink::<Frame<Ping>>::start_send(Pin::new(&mut lane), frame(9)).is_err(),
+        "a guarded write committed after close must not succeed"
+    );
+}
+
+// A send admitted before a close, delivered after it, must fail.
+//
+// Note what this does and does not cover: the added pre-check catches
+// this case, so the test passes with or without the `select(closing,
+// sending)` re-ordering that accompanies it. That re-ordering guards the
+// residual window where the close lands between the pre-check and the
+// poll, which is not reachable deterministically from here.
+// r[impl jetstream.session.lifetime]
+#[tokio::test]
+async fn an_ordered_send_admitted_before_a_close_fails() {
+    let pair = LocalSession::<TestProtocol>::pair();
+    let lane = pair.client.open_lane().await.unwrap();
+    let mut served = pair.server.accept_lane().await.unwrap();
+    let sender = lane.ordered_sender();
+
+    let ticket = sender.admit();
+    pair.client.close().await;
+
+    let err = timeout(Duration::from_secs(5), sender.deliver(ticket, frame(1)))
+        .await
+        .expect("must not hang")
+        .expect_err("a closed session must refuse the send");
+    assert!(matches!(err, SessionError::Closed));
+
+    let escaped = timeout(Duration::from_millis(100), served.next()).await;
+    if let Ok(Some(Ok(frame))) = escaped {
+        panic!("frame {:?} escaped a closed session", frame.msg);
+    }
+}
+
+// r[impl jetstream.lane.backpressure]
+#[test]
+#[should_panic(expected = "at least one frame")]
+fn a_zero_capacity_lane_is_rejected_at_construction() {
+    // Zero capacity cannot apply backpressure, only deadlock, and the
+    // channel underneath rejects it. Say so here rather than panicking
+    // inside the first open.
+    let _ = LocalSession::<TestProtocol>::pair_with_capacity(0);
+}

--- a/components/jetstream_rpc/src/session/tests.rs
+++ b/components/jetstream_rpc/src/session/tests.rs
@@ -940,3 +940,24 @@ fn a_zero_capacity_lane_is_rejected_at_construction() {
     // inside the first open.
     let _ = LocalSession::<TestProtocol>::pair_with_capacity(0);
 }
+
+// Regression: converting `SessionError::Transport` into `Error` returned
+// the inner error untouched, so the code the docs promised was never
+// there — a converted transport error was usually uninspectable.
+// r[impl jetstream.session.single-lane]
+#[test]
+fn a_converted_transport_error_is_always_inspectable() {
+    // An inner error with no code of its own gets the session's.
+    let bare: Error = SessionError::Transport(Error::new("boom")).into();
+    assert_eq!(bare.code(), Some(SessionError::TRANSPORT_CODE));
+
+    // An inner error that names itself keeps its own code, which says
+    // more than the session-level one would.
+    let specific: Error =
+        SessionError::Transport(Error::with_code("boom", "quic::reset")).into();
+    assert_eq!(specific.code(), Some("quic::reset"));
+
+    // Every other variant reports exactly its own code.
+    let closed: Error = SessionError::Closed.into();
+    assert_eq!(closed.code(), Some("jetstream::session::closed"));
+}

--- a/components/jetstream_rpc/src/session/tests.rs
+++ b/components/jetstream_rpc/src/session/tests.rs
@@ -1159,3 +1159,48 @@ async fn closing_a_lane_ends_it_even_with_a_writer_outstanding() {
 
     drop(retained);
 }
+
+// A frame queued while the lane closes is delivered, not dropped.
+//
+// The window is narrow: the reader has to find the queue empty, then
+// the opener has to enqueue *and* close before the reader checks the
+// token. Racing a send against a close is the only way to reach it from
+// outside the module, so this is a probabilistic probe rather than a
+// regression test, and the numbers are worth recording.
+//
+// Against the unfixed code it caught the dropped frame in one run out
+// of three at 256 iterations. Raising it to 2048 made it stop catching
+// it altogether — five runs, no failures — because the race wants a
+// cold runtime and warms out of it. So 256, deliberately, and not more.
+//
+// With the fix it passes every time, since the recheck removes the race
+// rather than narrowing it. A test that is never red on correct code
+// and sometimes red on broken code is worth keeping; one that is
+// sometimes red either way is not.
+// r[impl jetstream.lane.definition]
+#[tokio::test(flavor = "multi_thread")]
+async fn a_frame_queued_as_the_lane_closes_still_arrives() {
+    for _ in 0..256 {
+        let pair = LocalSession::<TestProtocol>::pair();
+        let mut lane = pair.client.open_lane().await.unwrap();
+        let mut served = pair.server.accept_lane().await.unwrap();
+
+        let reader = tokio::spawn(async move {
+            let mut seen = 0;
+            while let Some(frame) = served.next().await {
+                frame.expect("the lane should not error");
+                seen += 1;
+            }
+            seen
+        });
+
+        let sent = tokio::spawn(async move {
+            lane.send(frame(1)).await.unwrap();
+            lane.close().await.unwrap();
+        });
+
+        sent.await.unwrap();
+        let seen = reader.await.unwrap();
+        assert_eq!(seen, 1, "a frame whose send succeeded must arrive");
+    }
+}

--- a/components/jetstream_rpc/src/session/tests.rs
+++ b/components/jetstream_rpc/src/session/tests.rs
@@ -1224,3 +1224,37 @@ async fn a_frame_queued_as_the_lane_closes_still_arrives() {
         assert_eq!(seen, 1, "a frame whose send succeeded must arrive");
     }
 }
+
+// Regression: every lane's `admit` returns the same `OrderTicket` type,
+// so handing one lane's ticket to another compiled — and then waited on
+// the wrong lane's sequence while writing to this one.
+// r[impl jetstream.session.local.order-handoff]
+#[tokio::test]
+#[should_panic(expected = "ticket from another lane")]
+async fn a_ticket_from_another_lane_is_rejected() {
+    let pair = LocalSession::<TestProtocol>::pair();
+    let first = pair.client.open_lane().await.unwrap();
+    let second = pair.client.open_lane().await.unwrap();
+    let _served_first = pair.server.accept_lane().await.unwrap();
+    let _served_second = pair.server.accept_lane().await.unwrap();
+
+    let first_sender = first.ordered_sender().unwrap();
+    let second_sender = second.ordered_sender().unwrap();
+
+    // A place in the first lane's order, delivered on the second.
+    let stolen = first_sender.admit();
+    let _ = second_sender.deliver(stolen, frame(1)).await;
+}
+
+// r[impl jetstream.session.local.order-handoff]
+#[tokio::test]
+async fn a_lane_accepts_its_own_ticket() {
+    let pair = LocalSession::<TestProtocol>::pair();
+    let lane = pair.client.open_lane().await.unwrap();
+    let mut served = pair.server.accept_lane().await.unwrap();
+    let sender = lane.ordered_sender().unwrap();
+
+    let ticket = sender.admit();
+    assert!(sender.deliver(ticket, frame(3)).await.is_ok());
+    assert_eq!(served.next().await.unwrap().unwrap().msg, Ping(3));
+}

--- a/components/jetstream_rpc/src/session/tests.rs
+++ b/components/jetstream_rpc/src/session/tests.rs
@@ -1130,3 +1130,32 @@ async fn an_open_that_loses_to_a_close_reports_closed() {
         }
     }
 }
+
+// Regression: cancelling the lane token made `deliver` refuse, but an
+// `OrderedSender` the caller still held kept its channel handle alive,
+// so the peer went on waiting for a lane that was closed. The two
+// earlier tests each checked one half — EOF with no retained sender,
+// refusal without checking EOF — and neither combined them.
+// r[impl jetstream.lane.definition]
+#[tokio::test]
+async fn closing_a_lane_ends_it_even_with_a_writer_outstanding() {
+    let pair = LocalSession::<TestProtocol>::pair();
+    let mut lane = pair.client.open_lane().await.unwrap();
+    let mut served = pair.server.accept_lane().await.unwrap();
+
+    let retained = lane.ordered_sender().unwrap();
+    lane.send(frame(1)).await.unwrap();
+    lane.close().await.unwrap();
+
+    // A frame written before the close still arrives: closing says "no
+    // more items", not "discard the ones I sent".
+    assert_eq!(served.next().await.unwrap().unwrap().msg, Ping(1));
+
+    // ...and then the lane ends, with the writer still alive.
+    let ended = timeout(Duration::from_secs(5), served.next())
+        .await
+        .expect("the peer should see the lane end, not hang");
+    assert!(ended.is_none(), "expected the lane to end, got {ended:?}");
+
+    drop(retained);
+}

--- a/components/jetstream_rpc/src/session/tests.rs
+++ b/components/jetstream_rpc/src/session/tests.rs
@@ -1,5 +1,6 @@
 use std::{
     io::{self, Read, Write},
+    pin::Pin,
     sync::{Arc, Mutex},
     time::Duration,
 };
@@ -9,8 +10,9 @@ use tokio::time::timeout;
 
 use crate::{
     session::{
-        check_datagram_size, Capabilities, Capability, IdentityKind, LaneOrder,
-        LaneSupport, LocalSession, Session, SessionError, SingleLaneSession,
+        check_datagram_size, local::LocalSessionPair, Capabilities, Capability,
+        IdentityKind, LaneOrder, LaneSupport, LocalSession, Session,
+        SessionError, SingleLaneSession,
     },
     Error, Frame, Framer, Protocol,
 };
@@ -132,9 +134,20 @@ async fn closing_a_session_terminates_its_lanes() {
     let opened = pair.client.open_lane().await;
     assert!(matches!(opened, Err(SessionError::Closed)));
 
-    // The peer's end of the lane is unaffected by our close: its own
-    // session is still open, and it sees the lane end.
-    let _ = timeout(Duration::from_millis(200), served.next()).await;
+    // r[impl jetstream.session.lifetime]
+    // The peer's end terminates too. A lane has two ends, and leaving
+    // the far one waiting on a lane whose opener has gone is the hang
+    // this requirement exists to prevent.
+    let peer = timeout(Duration::from_millis(500), served.next())
+        .await
+        .expect("the peer's end must not hang on a closed session");
+    match peer {
+        Some(Err(err)) => {
+            assert_eq!(err.code(), Some("jetstream::session::closed"))
+        }
+        None => {}
+        Some(Ok(frame)) => panic!("unexpected frame {:?}", frame.msg),
+    }
 }
 
 // r[impl jetstream.session.lifetime]
@@ -724,4 +737,138 @@ async fn a_lane_opened_while_closing_is_born_closed() {
             }
         }
     }
+}
+
+// Regression: each end of a pair had its own token, so closing one side
+// left the peer's accepted lane live and its reads pending, and let the
+// closing side keep opening lanes nobody could ever accept.
+// r[impl jetstream.session.lifetime]
+#[tokio::test]
+async fn closing_one_end_terminates_the_peers_lanes() {
+    let pair = LocalSession::<TestProtocol>::pair();
+    let _lane = pair.client.open_lane().await.unwrap();
+    let mut served = pair.server.accept_lane().await.unwrap();
+
+    // The client lane is deliberately still held: its channel handles
+    // alone used to keep the peer's read pending forever.
+    pair.client.close().await;
+
+    let peer = timeout(Duration::from_millis(500), served.next())
+        .await
+        .expect("the peer's lane must terminate, not hang");
+    match peer {
+        Some(Err(err)) => {
+            assert_eq!(err.code(), Some("jetstream::session::closed"))
+        }
+        None => {}
+        Some(Ok(frame)) => panic!("unexpected frame {:?}", frame.msg),
+    }
+
+    // And the association is over for the peer as well: it neither
+    // accepts nor opens.
+    assert!(matches!(
+        pair.server.open_lane().await,
+        Err(SessionError::Closed)
+    ));
+    assert!(matches!(
+        timeout(Duration::from_millis(500), pair.server.accept_lane())
+            .await
+            .expect("accept must not hang after the peer closed"),
+        Err(SessionError::Closed)
+    ));
+}
+
+// Regression: closing the server used to leave the client happily
+// opening lanes that could never be accepted.
+// r[impl jetstream.session.lifetime]
+#[tokio::test]
+async fn closing_the_server_stops_the_client_opening() {
+    let pair = LocalSession::<TestProtocol>::pair();
+    pair.server.close().await;
+
+    assert!(matches!(
+        pair.client.open_lane().await,
+        Err(SessionError::Closed)
+    ));
+}
+
+// Regression: `poll_ready` could say yes, the session close, and
+// `start_send` then commit the write anyway and report success.
+// r[impl jetstream.session.lifetime]
+#[tokio::test]
+async fn a_write_committed_after_close_fails() {
+    use futures::Sink;
+
+    let pair = LocalSession::<TestProtocol>::pair();
+    let mut lane = pair.client.open_lane().await.unwrap();
+    let mut served = pair.server.accept_lane().await.unwrap();
+
+    // Reserve capacity first, exactly as a caller would before writing.
+    futures::future::poll_fn(|cx| {
+        Sink::<Frame<Ping>>::poll_ready(Pin::new(&mut lane), cx)
+    })
+    .await
+    .unwrap();
+
+    // The session closes between the reservation and the write.
+    pair.client.close().await;
+
+    let committed =
+        Sink::<Frame<Ping>>::start_send(Pin::new(&mut lane), frame(9));
+    assert!(
+        committed.is_err(),
+        "a write committed after close must not succeed"
+    );
+
+    // ...and nothing reached the peer.
+    let peer = timeout(Duration::from_millis(200), served.next()).await;
+    if let Ok(Some(Ok(frame))) = peer {
+        panic!("frame {:?} escaped a closed session", frame.msg);
+    }
+}
+
+// Regression: dropping the last session handle left its lanes usable,
+// because dropping a cancellation token does not cancel it.
+// r[impl jetstream.session.lifetime]
+#[tokio::test]
+async fn dropping_the_last_session_handle_terminates_its_lanes() {
+    let pair = LocalSession::<TestProtocol>::pair();
+    let mut lane = pair.client.open_lane().await.unwrap();
+    let sender = lane.ordered_sender();
+
+    let LocalSessionPair { client, server } = pair;
+    drop(client);
+    drop(server);
+
+    let err = timeout(Duration::from_millis(500), lane.next())
+        .await
+        .expect("a lane whose session is gone must not hang")
+        .expect("it reports the closure")
+        .expect_err("as an error");
+    assert_eq!(err.code(), Some("jetstream::session::closed"));
+
+    // Handles derived from the lane are done too.
+    let err = timeout(Duration::from_millis(500), sender.send(frame(1)))
+        .await
+        .expect("a derived sender must not hang either")
+        .expect_err("and must fail");
+    assert!(matches!(err, SessionError::Closed));
+}
+
+// r[impl jetstream.session.lifetime]
+#[tokio::test]
+async fn dropping_a_single_lane_session_terminates_its_lane() {
+    let pair = LocalSession::<TestProtocol>::pair();
+    let inner = pair.client.open_lane().await.unwrap();
+    let session = SingleLaneSession::<TestProtocol, _, _>::client(inner);
+    let mut lane = session.open_lane().await.unwrap();
+
+    drop(session);
+
+    let err = timeout(Duration::from_millis(500), lane.next())
+        .await
+        .expect("a lane whose session is gone must not hang")
+        .expect("it reports the closure")
+        .expect_err("as an error");
+    assert_eq!(err.code(), Some("jetstream::session::closed"));
 }

--- a/components/jetstream_rpc/src/session/tests.rs
+++ b/components/jetstream_rpc/src/session/tests.rs
@@ -1,0 +1,333 @@
+use std::{
+    io::{self, Read, Write},
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+use futures::{SinkExt, StreamExt};
+use tokio::time::timeout;
+
+use crate::{
+    session::{
+        check_datagram_size, Capabilities, Capability, IdentityKind, LaneOrder,
+        LaneSupport, LocalSession, Session, SessionError, SingleLaneSession,
+    },
+    Error, Frame, Framer, Protocol,
+};
+
+#[derive(Debug, PartialEq, Eq)]
+struct Ping(u32);
+
+impl Framer for Ping {
+    fn message_type(&self) -> u8 {
+        1
+    }
+
+    fn byte_size(&self) -> u32 {
+        4
+    }
+
+    fn encode<W: Write>(&self, writer: &mut W) -> io::Result<()> {
+        writer.write_all(&self.0.to_le_bytes())
+    }
+
+    fn decode<R: Read>(reader: &mut R, _ty: u8) -> io::Result<Self> {
+        let mut buf = [0u8; 4];
+        reader.read_exact(&mut buf)?;
+        Ok(Ping(u32::from_le_bytes(buf)))
+    }
+}
+
+#[derive(Debug)]
+struct TestProtocol;
+
+impl Protocol for TestProtocol {
+    type Error = Error;
+    type Request = Ping;
+    type Response = Ping;
+
+    const NAME: &'static str = "test";
+    const VERSION: &'static str = "dev";
+}
+
+fn frame(n: u32) -> Frame<Ping> {
+    Frame {
+        tag: n as u16,
+        msg: Ping(n),
+    }
+}
+
+// r[impl jetstream.session.local]
+#[tokio::test]
+async fn in_process_session_reports_its_row() {
+    let pair = LocalSession::<TestProtocol>::pair();
+    let caps = pair.client.capabilities();
+    assert_eq!(caps.lanes, LaneSupport::Many);
+    assert!(!caps.datagrams);
+    assert_eq!(caps.identity, IdentityKind::None);
+    assert!(!caps.migration);
+}
+
+// r[impl jetstream.lane.delivery-order]
+#[tokio::test]
+async fn a_lane_delivers_in_write_order() {
+    let pair = LocalSession::<TestProtocol>::pair();
+    let mut lane = pair.client.open_lane().await.unwrap();
+    let mut served = pair.server.accept_lane().await.unwrap();
+
+    for n in 0..8 {
+        lane.send(frame(n)).await.unwrap();
+    }
+
+    for n in 0..8 {
+        let got = served.next().await.unwrap().unwrap();
+        assert_eq!(got.msg, Ping(n));
+    }
+}
+
+// r[impl jetstream.lane.independence]
+#[tokio::test]
+async fn a_stalled_lane_does_not_block_another() {
+    let pair = LocalSession::<TestProtocol>::pair();
+    let mut quiet = pair.client.open_lane().await.unwrap();
+    let mut busy = pair.client.open_lane().await.unwrap();
+    let mut served_quiet = pair.server.accept_lane().await.unwrap();
+    let mut served_busy = pair.server.accept_lane().await.unwrap();
+
+    // Nothing is written to the first lane at all.
+    busy.send(frame(7)).await.unwrap();
+    let got = served_busy.next().await.unwrap().unwrap();
+    assert_eq!(got.msg, Ping(7));
+
+    // ...and the second lane still carries nothing, rather than the
+    // first lane's silence having queued behind it.
+    let idle = timeout(Duration::from_millis(50), served_quiet.next()).await;
+    assert!(idle.is_err(), "quiet lane should still be waiting");
+
+    quiet.send(frame(1)).await.unwrap();
+    let got = served_quiet.next().await.unwrap().unwrap();
+    assert_eq!(got.msg, Ping(1));
+}
+
+// r[impl jetstream.session.lifetime]
+#[tokio::test]
+async fn closing_a_session_terminates_its_lanes() {
+    let pair = LocalSession::<TestProtocol>::pair();
+    let mut lane = pair.client.open_lane().await.unwrap();
+    let mut served = pair.server.accept_lane().await.unwrap();
+
+    pair.client.close().await;
+
+    // The call in flight fails rather than hanging.
+    let err = timeout(Duration::from_millis(200), lane.next())
+        .await
+        .expect("closed lane must not hang")
+        .expect("closed lane reports before ending")
+        .expect_err("closed lane reports an error");
+    assert_eq!(err.code(), Some("jetstream::session::closed"));
+
+    assert!(lane.send(frame(1)).await.is_err());
+
+    // Opening a new lane on a closed session fails too.
+    let opened = pair.client.open_lane().await;
+    assert!(matches!(opened, Err(SessionError::Closed)));
+
+    // The peer's end of the lane is unaffected by our close: its own
+    // session is still open, and it sees the lane end.
+    let _ = timeout(Duration::from_millis(200), served.next()).await;
+}
+
+// r[impl jetstream.session.lifetime]
+#[tokio::test]
+async fn closing_a_lane_does_not_close_its_session() {
+    let pair = LocalSession::<TestProtocol>::pair();
+    let lane = pair.client.open_lane().await.unwrap();
+    let _served = pair.server.accept_lane().await.unwrap();
+    drop(lane);
+
+    let second = pair.client.open_lane().await;
+    assert!(second.is_ok(), "session outlives one of its lanes");
+}
+
+// r[impl jetstream.session.single-lane]
+#[tokio::test]
+async fn a_single_lane_session_opens_once() {
+    let pair = LocalSession::<TestProtocol>::pair();
+    let lane = pair.client.open_lane().await.unwrap();
+    let session = SingleLaneSession::<TestProtocol, _, _>::client(lane)
+        .with_identity(IdentityKind::None);
+
+    assert_eq!(session.capabilities().lanes, LaneSupport::One);
+    assert!(session.open_lane().await.is_ok());
+
+    let err = session.open_lane().await.expect_err("one lane only");
+    assert!(matches!(err, SessionError::LaneLimitReached));
+    assert_eq!(err.code(), "jetstream::session::lane_limit_reached");
+
+    // ...and it is inspectable once it has become a jetstream Error.
+    let as_error: Error = err.into();
+    assert_eq!(
+        as_error.code(),
+        Some("jetstream::session::lane_limit_reached")
+    );
+}
+
+// r[impl jetstream.session.single-lane]
+#[tokio::test]
+async fn a_client_side_single_lane_session_accepts_nothing() {
+    let pair = LocalSession::<TestProtocol>::pair();
+    let lane = pair.client.open_lane().await.unwrap();
+    let session = SingleLaneSession::<TestProtocol, _, _>::client(lane);
+
+    let err = session.accept_lane().await.expect_err("no accept side");
+    assert!(matches!(err, SessionError::AcceptUnsupported));
+}
+
+// r[impl jetstream.session.capabilities.degradation]
+#[test]
+fn asking_for_a_missing_capability_fails_explicitly() {
+    let byte_stream = Capabilities::byte_stream();
+    let err = byte_stream
+        .require(Capability::ManyLanes)
+        .expect_err("a byte stream carries one lane");
+    assert!(matches!(err, SessionError::Unsupported(_)));
+
+    assert!(Capabilities::iroh().require(Capability::ManyLanes).is_ok());
+    assert!(Capabilities::iroh().require(Capability::Datagrams).is_ok());
+}
+
+// r[impl jetstream.session.identity.addressing]
+#[test]
+fn key_identity_needs_no_address() {
+    assert!(!IdentityKind::Key.requires_address());
+    assert!(IdentityKind::Certificate.requires_address());
+    assert!(IdentityKind::None.requires_address());
+    assert!(Capabilities::iroh().supports(Capability::KeyAddressing));
+    assert!(!Capabilities::quic().supports(Capability::KeyAddressing));
+}
+
+// r[impl jetstream.session.datagrams]
+#[test]
+fn an_oversized_datagram_is_rejected_at_the_send_site() {
+    let frame = frame(1);
+    assert!(check_datagram_size(&frame, None).is_ok());
+    assert!(check_datagram_size(&frame, Some(1200)).is_ok());
+
+    let err = check_datagram_size(&frame, Some(4))
+        .expect_err("a frame larger than the path limit");
+    assert!(matches!(err, SessionError::DatagramTooLarge { .. }));
+}
+
+// r[impl jetstream.session.local.order-handoff]
+#[tokio::test(flavor = "multi_thread")]
+async fn delivery_keeps_the_order_taken_at_the_call_site() {
+    let order = LaneOrder::new();
+    let log = Arc::new(Mutex::new(Vec::new()));
+
+    // Tickets are taken here, in this order...
+    let tickets: Vec<_> = (0..8).map(|n| (n, order.ticket())).collect();
+
+    // ...and admitted in the opposite one.
+    let mut handles = Vec::new();
+    for (n, ticket) in tickets.into_iter().rev() {
+        let log = log.clone();
+        handles.push(tokio::spawn(async move {
+            ticket.wait().await;
+            log.lock().unwrap().push(n);
+            ticket.complete();
+        }));
+    }
+
+    for handle in handles {
+        timeout(Duration::from_secs(5), handle)
+            .await
+            .expect("ordered delivery must not deadlock")
+            .unwrap();
+    }
+
+    let delivered = log.lock().unwrap().clone();
+    assert_eq!(delivered, (0..8).collect::<Vec<_>>());
+}
+
+// r[impl jetstream.session.local.order-handoff]
+#[tokio::test]
+async fn an_abandoned_frame_passes_its_place_on() {
+    let order = LaneOrder::new();
+    let first = order.ticket();
+    let second = order.ticket();
+    let third = order.ticket();
+
+    // The first frame is abandoned before delivery: its place goes to
+    // the next frame on the lane rather than being released.
+    drop(first);
+
+    timeout(Duration::from_secs(5), second.wait())
+        .await
+        .expect("the abandoned place must pass on");
+    second.complete();
+
+    timeout(Duration::from_secs(5), third.wait())
+        .await
+        .expect("delivery continues in order");
+    third.complete();
+}
+
+// r[impl jetstream.session.local.order-handoff]
+#[tokio::test]
+async fn a_place_abandoned_out_of_turn_is_skipped() {
+    let order = LaneOrder::new();
+    let first = order.ticket();
+    let second = order.ticket();
+    let third = order.ticket();
+
+    // The middle frame is abandoned while the first is still in flight.
+    drop(second);
+    first.wait().await;
+    first.complete();
+
+    timeout(Duration::from_secs(5), third.wait())
+        .await
+        .expect("the skipped place must not stall the lane");
+    assert_eq!(order.turn(), third.seq());
+    third.complete();
+}
+
+// r[impl jetstream.session.local.order-handoff]
+#[tokio::test(flavor = "multi_thread")]
+async fn an_ordered_sender_writes_in_admission_order() {
+    let pair = LocalSession::<TestProtocol>::pair();
+    let lane = pair.client.open_lane().await.unwrap();
+    let mut served = pair.server.accept_lane().await.unwrap();
+    let sender = lane.ordered_sender();
+
+    let admitted: Vec<_> =
+        (0..8).map(|n| (n, sender.admit())).collect::<Vec<_>>();
+
+    let mut handles = Vec::new();
+    for (n, ticket) in admitted.into_iter().rev() {
+        let sender = sender.clone();
+        handles.push(tokio::spawn(async move {
+            sender.deliver(ticket, frame(n)).await.unwrap();
+        }));
+    }
+    for handle in handles {
+        handle.await.unwrap();
+    }
+
+    for n in 0..8 {
+        let got = served.next().await.unwrap().unwrap();
+        assert_eq!(got.msg, Ping(n));
+    }
+}
+
+// r[impl jetstream.session.symmetric]
+#[tokio::test]
+async fn either_end_may_open_a_lane() {
+    let pair = LocalSession::<TestProtocol>::pair();
+    let mut upstream = pair.server.open_lane().await.unwrap();
+    let mut served = pair.client.accept_lane().await.unwrap();
+
+    upstream.send(frame(3)).await.unwrap();
+    let got = served.next().await.unwrap().unwrap();
+    assert_eq!(got.msg, Ping(3));
+}

--- a/components/jetstream_rpc/src/session/tests.rs
+++ b/components/jetstream_rpc/src/session/tests.rs
@@ -312,7 +312,7 @@ async fn an_ordered_sender_writes_in_admission_order() {
     let pair = LocalSession::<TestProtocol>::pair();
     let lane = pair.client.open_lane().await.unwrap();
     let mut served = pair.server.accept_lane().await.unwrap();
-    let sender = lane.ordered_sender();
+    let sender = lane.ordered_sender().unwrap();
 
     let admitted: Vec<_> =
         (0..8).map(|n| (n, sender.admit())).collect::<Vec<_>>();
@@ -616,7 +616,7 @@ async fn an_ordered_sender_stops_when_its_session_closes() {
     let pair = LocalSession::<TestProtocol>::pair();
     let lane = pair.client.open_lane().await.unwrap();
     let mut served = pair.server.accept_lane().await.unwrap();
-    let sender = lane.ordered_sender();
+    let sender = lane.ordered_sender().unwrap();
 
     sender.send(frame(1)).await.unwrap();
     let got = served.next().await.unwrap().unwrap();
@@ -650,7 +650,7 @@ async fn a_parked_ordered_send_gives_up_when_the_session_closes() {
     let pair = LocalSession::<TestProtocol>::pair_with_capacity(1);
     let lane = pair.client.open_lane().await.unwrap();
     let _served = pair.server.accept_lane().await.unwrap();
-    let sender = lane.ordered_sender();
+    let sender = lane.ordered_sender().unwrap();
 
     // Fill the lane so the next send has to wait for room.
     sender.send(frame(0)).await.unwrap();
@@ -835,7 +835,7 @@ async fn a_write_committed_after_close_fails() {
 async fn dropping_the_last_session_handle_terminates_its_lanes() {
     let pair = LocalSession::<TestProtocol>::pair();
     let mut lane = pair.client.open_lane().await.unwrap();
-    let sender = lane.ordered_sender();
+    let sender = lane.ordered_sender().unwrap();
 
     let LocalSessionPair { client, server } = pair;
     drop(client);
@@ -915,7 +915,7 @@ async fn an_ordered_send_admitted_before_a_close_fails() {
     let pair = LocalSession::<TestProtocol>::pair();
     let lane = pair.client.open_lane().await.unwrap();
     let mut served = pair.server.accept_lane().await.unwrap();
-    let sender = lane.ordered_sender();
+    let sender = lane.ordered_sender().unwrap();
 
     let ticket = sender.admit();
     pair.client.close().await;
@@ -1033,4 +1033,100 @@ async fn a_parked_guarded_close_gives_up_when_the_session_closes() {
         ended.unwrap_err().code(),
         Some("jetstream::session::closed")
     );
+}
+
+// Regression: the lane kept a second handle on its channel for
+// `OrderedSender` clones, and `poll_close` closed only the sink's. The
+// peer therefore never saw the end of the lane, and a "closed" lane went
+// on handing out writers.
+// r[impl jetstream.lane.definition]
+#[tokio::test]
+async fn closing_a_lane_ends_it_for_the_peer() {
+    let pair = LocalSession::<TestProtocol>::pair();
+    let mut lane = pair.client.open_lane().await.unwrap();
+    let mut served = pair.server.accept_lane().await.unwrap();
+
+    lane.send(frame(1)).await.unwrap();
+    assert_eq!(served.next().await.unwrap().unwrap().msg, Ping(1));
+
+    lane.close().await.unwrap();
+
+    // The peer sees the end rather than waiting on a channel that a
+    // spare handle was holding open.
+    let ended = timeout(Duration::from_secs(5), served.next())
+        .await
+        .expect("the peer should see the lane end, not hang");
+    assert!(ended.is_none(), "expected the lane to end, got {ended:?}");
+
+    // ...and the closed lane hands out no new writers.
+    assert!(matches!(
+        lane.ordered_sender(),
+        Err(SessionError::LaneClosed)
+    ));
+
+    // r[impl jetstream.session.lifetime]
+    // Closing a lane does not close its session: another one opens.
+    assert!(pair.client.open_lane().await.is_ok());
+}
+
+// r[impl jetstream.lane.definition]
+#[tokio::test]
+async fn closing_a_lane_stops_a_sender_already_handed_out() {
+    let pair = LocalSession::<TestProtocol>::pair();
+    let mut lane = pair.client.open_lane().await.unwrap();
+    let _served = pair.server.accept_lane().await.unwrap();
+
+    let sender = lane.ordered_sender().unwrap();
+    lane.close().await.unwrap();
+
+    let ticket = sender.admit();
+    let err = timeout(Duration::from_secs(5), sender.deliver(ticket, frame(1)))
+        .await
+        .expect("a send on a closed lane must not hang")
+        .expect_err("a send on a closed lane must fail");
+    assert!(matches!(err, SessionError::Closed));
+}
+
+// Regression: `close` cancels and then empties the lane slots, so an
+// open that had already passed the closed check and was waiting on the
+// lock found an empty slot and reported `LaneLimitReached` — "you have
+// already had your one lane" — for a session that had closed.
+//
+// Being straight about what this covers: **it does not reproduce the
+// window.** Reaching it needs the open parked on the lock at the moment
+// `close` takes it, and from outside the module there is no way to hold
+// that lock — the open either wins outright or sees the closure at the
+// check above. I ran it against the unfixed code three times and it
+// passed every time, so it is not a regression test for this fix.
+//
+// It stays because the invariant it asserts is worth pinning against
+// changes of another shape: an open that fails on a closing session
+// says `Closed`, never the limit. Verifying the fix itself would need a
+// test-only hook into the lock, which is not worth the public surface.
+// r[impl jetstream.session.lifetime]
+#[tokio::test(flavor = "multi_thread")]
+async fn an_open_that_loses_to_a_close_reports_closed() {
+    for _ in 0..64 {
+        let pair = LocalSession::<TestProtocol>::pair();
+        let inner = pair.client.open_lane().await.unwrap();
+        let session =
+            Arc::new(SingleLaneSession::<TestProtocol, _, _>::client(inner));
+
+        let opener = {
+            let session = session.clone();
+            tokio::spawn(async move { session.open_lane().await.err() })
+        };
+        let closer = {
+            let session = session.clone();
+            tokio::spawn(async move { session.close().await })
+        };
+
+        let (opened, _) = tokio::join!(opener, closer);
+        if let Some(err) = opened.unwrap() {
+            assert!(
+                matches!(err, SessionError::Closed),
+                "an open losing to a close must say so, got {err:?}"
+            );
+        }
+    }
 }

--- a/components/jetstream_rpc/src/session/tests.rs
+++ b/components/jetstream_rpc/src/session/tests.rs
@@ -1084,7 +1084,27 @@ async fn closing_a_lane_stops_a_sender_already_handed_out() {
         .await
         .expect("a send on a closed lane must not hang")
         .expect_err("a send on a closed lane must fail");
-    assert!(matches!(err, SessionError::Closed));
+
+    // r[impl jetstream.session.lifetime]
+    // The *lane* closed, not the session. Reporting `Closed` here would
+    // tell a caller the association was over — a caller deciding
+    // whether to retry would stop — when another lane still opens.
+    assert!(
+        matches!(err, SessionError::LaneClosed),
+        "a lane-only close must not report the session closed, got {err:?}"
+    );
+    assert!(pair.client.open_lane().await.is_ok());
+
+    // ...and when the session really does close, it says so.
+    let lane = pair.client.open_lane().await.unwrap();
+    let sender = lane.ordered_sender().unwrap();
+    let ticket = sender.admit();
+    pair.client.close().await;
+    let err = timeout(Duration::from_secs(5), sender.deliver(ticket, frame(1)))
+        .await
+        .expect("a send on a closed session must not hang")
+        .expect_err("a send on a closed session must fail");
+    assert!(matches!(err, SessionError::Closed), "got {err:?}");
 }
 
 // Regression: `close` cancels and then empties the lane slots, so an

--- a/components/jetstream_rpc/src/session/tests.rs
+++ b/components/jetstream_rpc/src/session/tests.rs
@@ -1,12 +1,13 @@
 use std::{
     io::{self, Read, Write},
     pin::Pin,
-    sync::{Arc, Mutex},
+    sync::{atomic::AtomicUsize, Arc, Mutex},
     time::Duration,
 };
 
 use futures::{SinkExt, StreamExt};
 use tokio::time::timeout;
+use tokio_util::sync::CancellationToken;
 
 use crate::{
     session::{
@@ -960,4 +961,76 @@ fn a_converted_transport_error_is_always_inspectable() {
     // Every other variant reports exactly its own code.
     let closed: Error = SessionError::Closed.into();
     assert_eq!(closed.code(), Some("jetstream::session::closed"));
+}
+
+// Regression: `LaneGuard::poll_close` was the one sink method that did
+// not consult the lifetime, so a close already parked on the wrapped
+// lane never woke when the session closed. Every other method — ready,
+// send, flush, next — did.
+// r[impl jetstream.session.lifetime]
+#[tokio::test]
+async fn a_parked_guarded_close_gives_up_when_the_session_closes() {
+    use std::task::Poll;
+
+    use futures::Sink;
+
+    use crate::session::lifetime::{LaneGuard, LaneLifetime};
+
+    /// A lane whose close never finishes, standing in for a transport
+    /// wedged behind a peer that has stopped reading.
+    struct NeverCloses;
+
+    impl Sink<Frame<Ping>> for NeverCloses {
+        type Error = Error;
+
+        fn poll_ready(
+            self: Pin<&mut Self>,
+            _: &mut std::task::Context<'_>,
+        ) -> Poll<Result<(), Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn start_send(
+            self: Pin<&mut Self>,
+            _: Frame<Ping>,
+        ) -> Result<(), Error> {
+            Ok(())
+        }
+
+        fn poll_flush(
+            self: Pin<&mut Self>,
+            _: &mut std::task::Context<'_>,
+        ) -> Poll<Result<(), Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn poll_close(
+            self: Pin<&mut Self>,
+            _: &mut std::task::Context<'_>,
+        ) -> Poll<Result<(), Error>> {
+            Poll::Pending
+        }
+    }
+
+    let token = CancellationToken::new();
+    let live = Arc::new(AtomicUsize::new(0));
+    let mut guard = LaneGuard::new(
+        NeverCloses,
+        LaneLifetime::new(token.child_token(), live),
+    );
+
+    // The close parks, since the lane never finishes closing.
+    let parked = timeout(Duration::from_millis(50), guard.close()).await;
+    assert!(parked.is_err(), "the close should still be waiting");
+
+    // Closing the session has to reach it.
+    token.cancel();
+
+    let ended = timeout(Duration::from_secs(5), guard.close())
+        .await
+        .expect("a parked close must give up when its session closes");
+    assert_eq!(
+        ended.unwrap_err().code(),
+        Some("jetstream::session::closed")
+    );
 }

--- a/components/jetstream_rpc/src/session/tests.rs
+++ b/components/jetstream_rpc/src/session/tests.rs
@@ -384,10 +384,11 @@ async fn concurrent_accepts_all_terminate_when_the_session_closes() {
 }
 
 // Regression: every lane ever opened used to leave a token behind, so a
-// session that opened many short-lived lanes grew without bound.
+// session that opened many short-lived lanes grew without bound. Lanes
+// now hold a child cancellation token, which deregisters on drop.
 // r[impl jetstream.session.lifetime]
 #[tokio::test]
-async fn dropped_lanes_do_not_accumulate_tokens() {
+async fn dropped_lanes_do_not_accumulate() {
     let pair = LocalSession::<TestProtocol>::pair();
 
     for _ in 0..64 {
@@ -397,12 +398,8 @@ async fn dropped_lanes_do_not_accumulate_tokens() {
         drop(served);
     }
 
-    assert!(
-        pair.client.token_slots() <= 2,
-        "token slots should track live lanes, not historical ones: {}",
-        pair.client.token_slots()
-    );
     assert_eq!(pair.client.live_lanes(), 0);
+    assert_eq!(pair.server.live_lanes(), 0);
 
     // Live lanes are still counted.
     let _held = pair.client.open_lane().await.unwrap();
@@ -595,4 +592,136 @@ async fn a_cancelled_write_does_not_wedge_the_lane() {
         .unwrap()
         .unwrap();
     assert_eq!(got.msg, Ping(2));
+}
+
+// Regression: an `OrderedSender` held only a channel handle, so after
+// its session closed it could still deliver to the peer.
+// r[impl jetstream.session.lifetime]
+#[tokio::test]
+async fn an_ordered_sender_stops_when_its_session_closes() {
+    let pair = LocalSession::<TestProtocol>::pair();
+    let lane = pair.client.open_lane().await.unwrap();
+    let mut served = pair.server.accept_lane().await.unwrap();
+    let sender = lane.ordered_sender();
+
+    sender.send(frame(1)).await.unwrap();
+    let got = served.next().await.unwrap().unwrap();
+    assert_eq!(got.msg, Ping(1));
+
+    pair.client.close().await;
+
+    let err = timeout(Duration::from_secs(5), sender.send(frame(2)))
+        .await
+        .expect("a closed session must not leave the sender hanging")
+        .expect_err("and the send must fail");
+    assert!(matches!(err, SessionError::Closed));
+
+    // Nothing reached the peer after the close.
+    let quiet = timeout(Duration::from_millis(100), served.next()).await;
+    match quiet {
+        Err(_) => {}
+        Ok(None) => {}
+        Ok(Some(Err(_))) => {}
+        Ok(Some(Ok(frame))) => {
+            panic!("frame {:?} escaped a closed session", frame.msg)
+        }
+    }
+}
+
+// Regression: a pending ordered send used to stay parked when the
+// session closed underneath it.
+// r[impl jetstream.session.lifetime]
+#[tokio::test(flavor = "multi_thread")]
+async fn a_parked_ordered_send_gives_up_when_the_session_closes() {
+    let pair = LocalSession::<TestProtocol>::pair_with_capacity(1);
+    let lane = pair.client.open_lane().await.unwrap();
+    let _served = pair.server.accept_lane().await.unwrap();
+    let sender = lane.ordered_sender();
+
+    // Fill the lane so the next send has to wait for room.
+    sender.send(frame(0)).await.unwrap();
+
+    let parked = {
+        let sender = sender.clone();
+        tokio::spawn(async move { sender.send(frame(1)).await })
+    };
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    pair.client.close().await;
+
+    let outcome = timeout(Duration::from_secs(5), parked)
+        .await
+        .expect("a parked send must give up when the session closes")
+        .unwrap();
+    assert!(matches!(outcome, Err(SessionError::Closed)));
+}
+
+// Regression: an accepted lane reported the framed stream's context, so
+// identity the session established during a handshake the stream never
+// saw — a TLS adapter's peer certificate — was lost before the handler.
+// r[impl jetstream.session.identity]
+#[tokio::test]
+async fn an_accepted_lane_reports_the_session_identity() {
+    use crate::context::{Context, Contextual, RemoteAddr};
+
+    let pair = LocalSession::<TestProtocol>::pair();
+    let _lane = pair.client.open_lane().await.unwrap();
+    let inner = pair.server.accept_lane().await.unwrap();
+
+    let session_context = Context::new(
+        Some(RemoteAddr::IpAddr("203.0.113.7".parse().unwrap())),
+        None,
+    );
+    let session = SingleLaneSession::<TestProtocol, _, _>::service(inner)
+        .with_identity(IdentityKind::Certificate)
+        .with_context(session_context.clone());
+
+    let served = session.accept_lane().await.unwrap();
+    assert_eq!(
+        Contextual::context(&served).remote(),
+        session_context.remote(),
+        "the handler must see the identity the session established"
+    );
+
+    // Without a session identity the lane's own context still stands.
+    let pair = LocalSession::<TestProtocol>::pair();
+    let _lane = pair.client.open_lane().await.unwrap();
+    let inner = pair.server.accept_lane().await.unwrap();
+    let plain = SingleLaneSession::<TestProtocol, _, _>::service(inner);
+    let served = plain.accept_lane().await.unwrap();
+    assert!(Contextual::context(&served).remote().is_none());
+}
+
+// Regression: a lane handed out concurrently with `close` could register
+// its token after `close` had cleared them, escaping cancellation.
+// r[impl jetstream.session.lifetime]
+#[tokio::test(flavor = "multi_thread")]
+async fn a_lane_opened_while_closing_is_born_closed() {
+    for _ in 0..64 {
+        let pair = LocalSession::<TestProtocol>::pair();
+        let client = pair.client.clone();
+
+        let opening = tokio::spawn(async move { client.open_lane().await });
+        pair.client.close().await;
+
+        if let Ok(mut lane) = opening.await.unwrap() {
+            // If a lane did come back, it must already be terminated
+            // rather than still usable on a closed session.
+            let outcome = timeout(Duration::from_secs(5), lane.next())
+                .await
+                .expect("a lane from a closed session must not hang");
+            match outcome {
+                Some(Err(err)) => {
+                    assert_eq!(err.code(), Some("jetstream::session::closed"))
+                }
+                None => {}
+                Some(Ok(frame)) => {
+                    panic!(
+                        "closed session yielded a live lane: {:?}",
+                        frame.msg
+                    )
+                }
+            }
+        }
+    }
 }

--- a/components/jetstream_rpc/src/session/tests.rs
+++ b/components/jetstream_rpc/src/session/tests.rs
@@ -331,3 +331,268 @@ async fn either_end_may_open_a_lane() {
     let got = served.next().await.unwrap().unwrap();
     assert_eq!(got.msg, Ping(3));
 }
+
+// Regression: a single-lane session used to become a no-op on close
+// once its lane had been handed out, leaving the lane running and an
+// in-flight call waiting on a session that had closed.
+// r[impl jetstream.session.lifetime]
+#[tokio::test]
+async fn closing_a_single_lane_session_terminates_the_handed_out_lane() {
+    let pair = LocalSession::<TestProtocol>::pair();
+    let inner = pair.client.open_lane().await.unwrap();
+    let session = SingleLaneSession::<TestProtocol, _, _>::client(inner);
+
+    let mut lane = session.open_lane().await.unwrap();
+    session.close().await;
+
+    let err = timeout(Duration::from_millis(200), lane.next())
+        .await
+        .expect("a closed session must not leave the lane hanging")
+        .expect("the lane reports the closure")
+        .expect_err("the lane reports it as an error");
+    assert_eq!(err.code(), Some("jetstream::session::closed"));
+
+    assert!(lane.send(frame(1)).await.is_err());
+    assert!(lane.next().await.is_none(), "and then the lane ends");
+}
+
+// Regression: the second of two concurrent accepts used to build its
+// wakeup after `close` had already woken the waiters, and wait forever.
+// r[impl jetstream.session.lifetime]
+#[tokio::test(flavor = "multi_thread")]
+async fn concurrent_accepts_all_terminate_when_the_session_closes() {
+    let pair = LocalSession::<TestProtocol>::pair();
+
+    let mut waiting = Vec::new();
+    for _ in 0..4 {
+        let server = pair.server.clone();
+        waiting.push(tokio::spawn(async move { server.accept_lane().await }));
+    }
+
+    // Let them reach the accept before closing: one holds the offers
+    // lock, the rest are queued behind it.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    pair.server.close().await;
+
+    for handle in waiting {
+        let outcome = timeout(Duration::from_secs(5), handle)
+            .await
+            .expect("every parked accept must wake on close")
+            .unwrap();
+        assert!(matches!(outcome, Err(SessionError::Closed)));
+    }
+}
+
+// Regression: every lane ever opened used to leave a token behind, so a
+// session that opened many short-lived lanes grew without bound.
+// r[impl jetstream.session.lifetime]
+#[tokio::test]
+async fn dropped_lanes_do_not_accumulate_tokens() {
+    let pair = LocalSession::<TestProtocol>::pair();
+
+    for _ in 0..64 {
+        let lane = pair.client.open_lane().await.unwrap();
+        let served = pair.server.accept_lane().await.unwrap();
+        drop(lane);
+        drop(served);
+    }
+
+    assert!(
+        pair.client.token_slots() <= 2,
+        "token slots should track live lanes, not historical ones: {}",
+        pair.client.token_slots()
+    );
+    assert_eq!(pair.client.live_lanes(), 0);
+
+    // Live lanes are still counted.
+    let _held = pair.client.open_lane().await.unwrap();
+    assert_eq!(pair.client.live_lanes(), 1);
+}
+
+// r[impl jetstream.lane.backpressure]
+#[tokio::test]
+async fn a_lane_reports_pending_rather_than_buffering_without_bound() {
+    use futures::FutureExt;
+
+    let pair = LocalSession::<TestProtocol>::pair_with_capacity(1);
+    let mut lane = pair.client.open_lane().await.unwrap();
+    let mut served = pair.server.accept_lane().await.unwrap();
+
+    // Write until the sink stops accepting immediately. A lane that
+    // buffered without bound would take all of these.
+    let mut written = 0u32;
+    for n in 0..64 {
+        match lane.send(frame(n)).now_or_never() {
+            Some(result) => {
+                result.unwrap();
+                written += 1;
+            }
+            None => break,
+        }
+    }
+    assert!(written > 0, "the lane accepted nothing at all");
+    assert!(
+        written < 64,
+        "a bounded lane must eventually report pending, wrote {written}"
+    );
+
+    // Draining the reader lets the writer proceed again.
+    for n in 0..written {
+        let got = timeout(Duration::from_secs(5), served.next())
+            .await
+            .expect("what the lane accepted must be readable")
+            .unwrap()
+            .unwrap();
+        assert_eq!(got.msg, Ping(n));
+    }
+    timeout(Duration::from_secs(5), lane.send(frame(written)))
+        .await
+        .expect("a drained lane accepts writes again")
+        .unwrap();
+}
+
+// r[impl jetstream.session.trait]
+#[tokio::test(flavor = "multi_thread")]
+async fn a_session_opens_lanes_from_several_tasks_at_once() {
+    let pair = LocalSession::<TestProtocol>::pair();
+
+    let mut opening = Vec::new();
+    for _ in 0..16 {
+        let client = pair.client.clone();
+        opening.push(tokio::spawn(async move { client.open_lane().await }));
+    }
+    for handle in opening {
+        handle
+            .await
+            .unwrap()
+            .expect("opening needs no exclusive access");
+    }
+
+    for _ in 0..16 {
+        timeout(Duration::from_secs(5), pair.server.accept_lane())
+            .await
+            .expect("every opened lane is offered")
+            .expect("and accepted");
+    }
+}
+
+// r[impl jetstream.lane.delivery-order]
+// r[impl jetstream.lane.no-cross-lane-order]
+#[tokio::test(flavor = "multi_thread")]
+async fn each_lane_keeps_its_own_order_while_lanes_interleave() {
+    let pair = LocalSession::<TestProtocol>::pair();
+
+    let mut lanes = Vec::new();
+    let mut served = Vec::new();
+    for _ in 0..4 {
+        lanes.push(pair.client.open_lane().await.unwrap());
+        served.push(pair.server.accept_lane().await.unwrap());
+    }
+
+    // Write to the lanes round-robin, so the lanes interleave on the
+    // wire while each one's own frames stay in order.
+    for n in 0..8u32 {
+        for (lane_index, lane) in lanes.iter_mut().enumerate() {
+            lane.send(frame(n * 10 + lane_index as u32)).await.unwrap();
+        }
+    }
+
+    for (lane_index, incoming) in served.iter_mut().enumerate() {
+        for n in 0..8u32 {
+            let got = incoming.next().await.unwrap().unwrap();
+            assert_eq!(
+                got.msg,
+                Ping(n * 10 + lane_index as u32),
+                "lane {lane_index} delivered out of order"
+            );
+        }
+    }
+}
+
+// r[impl jetstream.session.local.order-handoff]
+#[tokio::test(flavor = "multi_thread")]
+async fn order_survives_abandonment_scattered_through_the_queue() {
+    let order = LaneOrder::new();
+    let log = Arc::new(Mutex::new(Vec::new()));
+
+    let tickets: Vec<_> = (0..32u32).map(|n| (n, order.ticket())).collect();
+
+    // Abandon every third place; the rest must still arrive in order.
+    let mut expected = Vec::new();
+    let mut handles = Vec::new();
+    for (n, ticket) in tickets.into_iter().rev() {
+        if n % 3 == 0 {
+            drop(ticket);
+            continue;
+        }
+        expected.push(n);
+        let log = log.clone();
+        handles.push(tokio::spawn(async move {
+            ticket.wait().await;
+            log.lock().unwrap().push(n);
+            ticket.complete();
+        }));
+    }
+    expected.sort_unstable();
+
+    for handle in handles {
+        timeout(Duration::from_secs(5), handle)
+            .await
+            .expect("an abandoned place must not stall the lane")
+            .unwrap();
+    }
+
+    assert_eq!(*log.lock().unwrap(), expected);
+}
+
+// r[impl jetstream.session.local.order-handoff]
+#[tokio::test]
+async fn every_place_is_eventually_reached() {
+    let order = LaneOrder::new();
+    let tickets: Vec<_> = (0..16).map(|_| order.ticket()).collect();
+
+    assert_eq!(order.turn(), 0);
+    for (n, ticket) in tickets.into_iter().enumerate() {
+        assert_eq!(ticket.seq(), n as u64);
+        ticket.wait().await;
+        assert_eq!(order.turn(), n as u64);
+        ticket.complete();
+    }
+    assert_eq!(order.turn(), 16);
+}
+
+// r[impl jetstream.lane.backpressure]
+// A write that is cancelled — a `select!` arm that loses, a write under
+// a timeout — must not wedge the lane. `futures::channel::mpsc` refuses
+// every later write on a sender whose send future was dropped while
+// pending, which is why the lane does not use one.
+#[tokio::test]
+async fn a_cancelled_write_does_not_wedge_the_lane() {
+    let pair = LocalSession::<TestProtocol>::pair_with_capacity(1);
+    let mut lane = pair.client.open_lane().await.unwrap();
+    let mut served = pair.server.accept_lane().await.unwrap();
+
+    lane.send(frame(0)).await.unwrap();
+
+    // This one cannot complete: the lane holds one frame and nothing is
+    // reading. Cancel it.
+    let cancelled =
+        timeout(Duration::from_millis(50), lane.send(frame(1))).await;
+    assert!(cancelled.is_err(), "the lane should be full here");
+
+    // Draining lets writes proceed again.
+    let got = served.next().await.unwrap().unwrap();
+    assert_eq!(got.msg, Ping(0));
+
+    timeout(Duration::from_secs(5), lane.send(frame(2)))
+        .await
+        .expect("a cancelled write must not wedge the lane")
+        .unwrap();
+
+    let got = timeout(Duration::from_secs(5), served.next())
+        .await
+        .expect("and the frame arrives")
+        .unwrap()
+        .unwrap();
+    assert_eq!(got.msg, Ping(2));
+}

--- a/tests/iroh_session.rs
+++ b/tests/iroh_session.rs
@@ -196,7 +196,25 @@ async fn closing_a_session_terminates_its_lanes() {
     let mut served = pair.server.accept_lane().await.unwrap();
     assert_eq!(served.next().await.unwrap().unwrap().msg.as_str(), "hello");
 
+    // r[impl jetstream.session.lifetime]
+    // A datagram receive parked across the close ends the same way a
+    // lane does: the session closed, it did not fail.
+    let parked = {
+        let server = pair.server.clone();
+        tokio::spawn(async move { server.recv_datagram_bytes().await })
+    };
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
     Session::<TestProtocol>::close(&pair.server).await;
+
+    let ended = timeout(Duration::from_secs(10), parked)
+        .await
+        .expect("a parked datagram receive should not hang")
+        .unwrap();
+    assert!(
+        matches!(ended, Err(SessionError::Closed)),
+        "a parked receive should report Closed, got {ended:?}"
+    );
 
     let ended = timeout(Duration::from_secs(10), lane.next())
         .await

--- a/tests/iroh_session.rs
+++ b/tests/iroh_session.rs
@@ -385,3 +385,48 @@ async fn a_datagram_with_trailing_bytes_is_rejected() {
         "a datagram with trailing bytes is not a complete frame"
     );
 }
+
+// r[impl jetstream.session.capabilities.degradation]
+// Regression: `without_datagrams` reached the capability and the size
+// but not the two methods that carry traffic. `recv_datagram_bytes`
+// went on awaiting `read_datagram`, which on an endpoint with datagram
+// receive switched off never yields — so a caller that asked the
+// channel for a datagram parked until the whole connection closed,
+// which is the one failure mode the degradation rule exists to prevent.
+// A capability that is absent has to fail, and say which capability.
+#[tokio::test]
+async fn a_session_without_datagrams_refuses_datagram_traffic() {
+    let pair = pair().await;
+    let quiet = pair.client.clone().without_datagrams();
+
+    // The receive is the one that used to hang. A generous timeout, so
+    // that a regression fails here rather than wedging the suite: the
+    // refusal is a flag check and does not touch the network.
+    let refused = timeout(
+        Duration::from_secs(10),
+        Datagrams::<TestProtocol>::recv_datagram_bytes(&quiet),
+    )
+    .await
+    .expect("a session with no datagram channel must fail, not park");
+    assert!(
+        matches!(
+            refused,
+            Err(SessionError::Unsupported(Capability::Datagrams))
+        ),
+        "expected the capability to be named, got {refused:?}"
+    );
+
+    // Sending is refused for the same reason and by the same flag. The
+    // endpoint underneath this pair does carry datagrams, so without
+    // the check this send would have succeeded on a session reporting
+    // it has no channel to send on.
+    let sent = quiet.send_request_datagram(frame(1, "quiet")).await;
+    assert!(
+        matches!(sent, Err(SessionError::Unsupported(Capability::Datagrams))),
+        "expected the send to be refused, got {sent:?}"
+    );
+
+    // The peer is a different session and keeps its own channel: the
+    // override belongs to the handles on one side, not to the wire.
+    assert!(Session::<TestProtocol>::capabilities(&pair.server).datagrams);
+}

--- a/tests/iroh_session.rs
+++ b/tests/iroh_session.rs
@@ -16,13 +16,13 @@ use jetstream_iroh::IrohSession;
 use jetstream_rpc::{
     context::{Contextual, Peer},
     session::{
-        Capabilities, Datagrams, IdentityKind, LaneSupport, Session,
-        SessionError,
+        decode_datagram, Capabilities, Datagrams, IdentityKind, LaneSupport,
+        Session, SessionError,
     },
     Frame,
 };
 use jetstream_wireformat::WireFormat;
-use session_common::{frame, response, Ask, TestProtocol};
+use session_common::{frame, response, Ask, Say, TestProtocol};
 use tokio::time::timeout;
 
 const ALPN: &[u8] = b"jetstream-session-test";
@@ -241,11 +241,13 @@ async fn a_datagram_round_trips() {
         .await
         .unwrap();
 
-    let got =
-        timeout(Duration::from_secs(10), pair.server.recv_request_datagram())
+    let got: Frame<Ask> = decode_datagram(
+        timeout(Duration::from_secs(10), pair.server.recv_datagram_bytes())
             .await
             .expect("the request datagram should have arrived")
-            .unwrap();
+            .unwrap(),
+    )
+    .unwrap();
     assert_eq!(got.tag, 7);
     assert_eq!(got.msg.as_str(), "asked");
 
@@ -256,12 +258,12 @@ async fn a_datagram_round_trips() {
         .await
         .unwrap();
 
-    let got = timeout(
-        Duration::from_secs(10),
-        pair.client.recv_response_datagram(),
+    let got: Frame<Say> = decode_datagram(
+        timeout(Duration::from_secs(10), pair.client.recv_datagram_bytes())
+            .await
+            .expect("the response datagram should have arrived")
+            .unwrap(),
     )
-    .await
-    .expect("the response datagram should have arrived")
     .unwrap();
     assert_eq!(got.tag, 7);
     assert_eq!(got.msg.as_str(), "answered");
@@ -302,10 +304,12 @@ async fn a_datagram_with_trailing_bytes_is_rejected() {
 
     pair.client.connection().send_datagram(buf.into()).unwrap();
 
-    let got =
-        timeout(Duration::from_secs(10), pair.server.recv_request_datagram())
+    let bytes =
+        timeout(Duration::from_secs(10), pair.server.recv_datagram_bytes())
             .await
-            .expect("the datagram should have arrived");
+            .expect("the datagram should have arrived")
+            .unwrap();
+    let got = decode_datagram::<Ask>(bytes);
     assert!(
         got.is_err(),
         "a datagram with trailing bytes is not a complete frame"

--- a/tests/iroh_session.rs
+++ b/tests/iroh_session.rs
@@ -22,7 +22,7 @@ use jetstream_rpc::{
     Frame,
 };
 use jetstream_wireformat::WireFormat;
-use session_common::{frame, Blob, TestProtocol};
+use session_common::{frame, response, Ask, TestProtocol};
 use tokio::time::timeout;
 
 const ALPN: &[u8] = b"jetstream-session-test";
@@ -126,7 +126,7 @@ async fn each_lane_is_its_own_stream() {
     assert!(quiet.is_err(), "the first lane should be waiting");
 
     // r[impl jetstream.session.symmetric]
-    served_second.send(frame(2, "answered")).await.unwrap();
+    served_second.send(response(2, "answered")).await.unwrap();
     let got = second.next().await.unwrap().unwrap();
     assert_eq!(got.msg.as_str(), "answered");
 }
@@ -180,22 +180,82 @@ async fn closing_a_session_terminates_its_lanes() {
     assert!(opened.is_err(), "a closed session should not open a lane");
 }
 
+// Regression: `IrohSession` held the connection directly, so dropping
+// the last handle left the QUIC association up — every lane carries its
+// own clone of the connection, and those clones kept it alive. The local
+// and single-lane sessions got drop paths a round earlier; this one was
+// reported as fixed when it was not.
+// r[impl jetstream.session.lifetime]
+#[tokio::test(flavor = "multi_thread")]
+async fn dropping_the_last_session_handle_closes_the_connection() {
+    let pair = pair().await;
+
+    let mut lane = pair.client.open_lane().await.unwrap();
+    lane.send(frame(1, "hello")).await.unwrap();
+    let mut served = pair.server.accept_lane().await.unwrap();
+    assert_eq!(served.next().await.unwrap().unwrap().msg.as_str(), "hello");
+
+    // A clone is not the last handle, so the association survives it.
+    drop(pair.client.clone());
+    served.send(response(1, "still here")).await.unwrap();
+    assert_eq!(
+        lane.next().await.unwrap().unwrap().msg.as_str(),
+        "still here"
+    );
+
+    // The last one is. Note the lane is deliberately still alive: it
+    // holds its own clone of the connection, which is what used to keep
+    // the association up after its session had gone.
+    let Pair { client, .. } = pair;
+    drop(client);
+
+    let ended = timeout(Duration::from_secs(10), lane.next())
+        .await
+        .expect("the lane should have terminated, not hung");
+    assert!(
+        matches!(ended, Some(Err(_))),
+        "a lane whose session was dropped should fail, got {ended:?}"
+    );
+}
+
 // r[impl jetstream.session.datagrams]
 #[tokio::test(flavor = "multi_thread")]
 async fn a_datagram_round_trips() {
     let pair = pair().await;
 
+    // r[impl jetstream.session.symmetric]
+    // The caller sends a request and the callee receives a request. The
+    // API named the roles the other way round until this test's protocol
+    // stopped sharing one type between them.
     pair.client
-        .send_datagram(frame(7, "unordered"))
+        .send_request_datagram(frame(7, "asked"))
         .await
         .unwrap();
 
-    let got = timeout(Duration::from_secs(10), pair.server.recv_datagram())
-        .await
-        .expect("the datagram should have arrived")
-        .unwrap();
+    let got =
+        timeout(Duration::from_secs(10), pair.server.recv_request_datagram())
+            .await
+            .expect("the request datagram should have arrived")
+            .unwrap();
     assert_eq!(got.tag, 7);
-    assert_eq!(got.msg.as_str(), "unordered");
+    assert_eq!(got.msg.as_str(), "asked");
+
+    // ...and back the other way, which is the direction a session that
+    // decoded by the wrong role would have got right by accident.
+    pair.server
+        .send_response_datagram(response(7, "answered"))
+        .await
+        .unwrap();
+
+    let got = timeout(
+        Duration::from_secs(10),
+        pair.client.recv_response_datagram(),
+    )
+    .await
+    .expect("the response datagram should have arrived")
+    .unwrap();
+    assert_eq!(got.tag, 7);
+    assert_eq!(got.msg.as_str(), "answered");
 }
 
 // r[impl jetstream.session.datagrams]
@@ -208,11 +268,11 @@ async fn an_oversized_datagram_is_rejected_at_the_sender() {
 
     let too_big = Frame {
         tag: 1,
-        msg: Blob::of(limit as usize + 1),
+        msg: Ask::of(limit as usize + 1),
     };
     assert!(WireFormat::byte_size(&too_big) > limit);
 
-    match pair.client.send_datagram(too_big).await {
+    match pair.client.send_request_datagram(too_big).await {
         Err(SessionError::DatagramTooLarge { limit: got, .. }) => {
             assert_eq!(got, limit)
         }
@@ -233,9 +293,10 @@ async fn a_datagram_with_trailing_bytes_is_rejected() {
 
     pair.client.connection().send_datagram(buf.into()).unwrap();
 
-    let got = timeout(Duration::from_secs(10), pair.server.recv_datagram())
-        .await
-        .expect("the datagram should have arrived");
+    let got =
+        timeout(Duration::from_secs(10), pair.server.recv_request_datagram())
+            .await
+            .expect("the datagram should have arrived");
     assert!(
         got.is_err(),
         "a datagram with trailing bytes is not a complete frame"

--- a/tests/iroh_session.rs
+++ b/tests/iroh_session.rs
@@ -16,8 +16,8 @@ use jetstream_iroh::IrohSession;
 use jetstream_rpc::{
     context::{Contextual, Peer},
     session::{
-        decode_datagram, Capabilities, Datagrams, IdentityKind, LaneSupport,
-        Session, SessionError,
+        decode_datagram, Capabilities, Capability, Datagrams, IdentityKind,
+        LaneSupport, Session, SessionError,
     },
     Frame,
 };
@@ -103,6 +103,21 @@ async fn an_iroh_session_reports_its_row() {
         Datagrams::<TestProtocol>::max_datagram_size(&pair.client).is_some(),
         "the reported capability should match the connection"
     );
+
+    // r[impl jetstream.session.capabilities]
+    // `max_datagram_size` reads the *peer's* advertised limit, so it
+    // cannot see this endpoint's own configuration. A caller that
+    // switched datagrams off locally says so, and both the capability
+    // and the size follow — otherwise the size would keep saying yes
+    // while every send failed.
+    let quiet = pair.client.clone().without_datagrams();
+    assert!(!Session::<TestProtocol>::capabilities(&quiet).datagrams);
+    assert!(Datagrams::<TestProtocol>::max_datagram_size(&quiet).is_none());
+    assert!(matches!(
+        Session::<TestProtocol>::capabilities(&quiet)
+            .require(Capability::Datagrams),
+        Err(SessionError::Unsupported(Capability::Datagrams))
+    ));
 
     // r[impl jetstream.session.identity.addressing]
     // The key is the address, so a caller never has to carry placement

--- a/tests/iroh_session.rs
+++ b/tests/iroh_session.rs
@@ -110,8 +110,16 @@ async fn an_iroh_session_reports_its_row() {
     // switched datagrams off locally says so, and both the capability
     // and the size follow — otherwise the size would keep saying yes
     // while every send failed.
+    // The override is shared, so a clone taken *before* it follows too
+    // — otherwise a handle held elsewhere would keep claiming a channel
+    // that carries nothing.
+    let earlier_clone = pair.client.clone();
     let quiet = pair.client.clone().without_datagrams();
     assert!(!Session::<TestProtocol>::capabilities(&quiet).datagrams);
+    assert!(
+        !Session::<TestProtocol>::capabilities(&earlier_clone).datagrams,
+        "a clone taken before the override must follow it"
+    );
     assert!(Datagrams::<TestProtocol>::max_datagram_size(&quiet).is_none());
     assert!(matches!(
         Session::<TestProtocol>::capabilities(&quiet)
@@ -289,18 +297,27 @@ async fn a_datagram_round_trips() {
 async fn an_oversized_datagram_is_rejected_at_the_sender() {
     let pair = pair().await;
 
-    let limit = Datagrams::<TestProtocol>::max_datagram_size(&pair.client)
-        .expect("iroh should report a datagram limit");
-
+    // Sized past anything QUIC can ever carry, rather than one byte
+    // over the limit read a moment ago. That is how this test first
+    // failed on Windows CI: the limit is bounded by the path MTU, MTU
+    // discovery raised it between the read and the send, and a frame
+    // that had been one byte too large fit. A datagram cannot exceed
+    // 65527 bytes under any MTU, so this one is over by construction.
     let too_big = Frame {
         tag: 1,
-        msg: Ask::of(limit as usize + 1),
+        msg: Ask::of(u16::MAX as usize),
     };
+
+    let limit = Datagrams::<TestProtocol>::max_datagram_size(&pair.client)
+        .expect("iroh should report a datagram limit");
     assert!(WireFormat::byte_size(&too_big) > limit);
 
     match pair.client.send_request_datagram(too_big).await {
-        Err(SessionError::DatagramTooLarge { limit: got, .. }) => {
-            assert_eq!(got, limit)
+        Err(SessionError::DatagramTooLarge { size, limit: got }) => {
+            assert!(
+                size > got,
+                "the refusal should name a frame over the limit"
+            );
         }
         other => panic!("expected DatagramTooLarge, got {other:?}"),
     }

--- a/tests/iroh_session.rs
+++ b/tests/iroh_session.rs
@@ -1,0 +1,243 @@
+//! The iroh session binding, over a real handshake.
+//!
+//! r[impl jetstream.session.conformance.iroh]
+//! The tests run against a local relay server, so nothing here reaches
+//! the public relay network.
+
+#![cfg(feature = "iroh")]
+
+mod session_common;
+
+use std::time::Duration;
+
+use futures::{SinkExt, StreamExt};
+use iroh::{endpoint::presets, tls::CaTlsConfig, Endpoint, RelayMode};
+use jetstream_iroh::IrohSession;
+use jetstream_rpc::{
+    context::{Contextual, Peer},
+    session::{
+        Capabilities, Datagrams, IdentityKind, LaneSupport, Session,
+        SessionError,
+    },
+    Frame,
+};
+use jetstream_wireformat::WireFormat;
+use session_common::{frame, Blob, TestProtocol};
+use tokio::time::timeout;
+
+const ALPN: &[u8] = b"jetstream-session-test";
+
+/// A connected pair of sessions over one iroh connection, plus the
+/// relay the two endpoints found each other through.
+struct Pair {
+    client: IrohSession<TestProtocol>,
+    server: IrohSession<TestProtocol>,
+    client_id: String,
+    server_id: String,
+    // The relay stays up for as long as the pair does. Its type is
+    // not re-exported from `iroh`, so it is held opaquely.
+    _relay: Box<dyn std::any::Any + Send>,
+}
+
+async fn pair() -> Pair {
+    let (relay_map, _relay_url, relay) =
+        iroh::test_utils::run_relay_server().await.unwrap();
+
+    let server_endpoint = Endpoint::builder(presets::Minimal)
+        .relay_mode(RelayMode::Custom(relay_map.clone()))
+        .ca_tls_config(CaTlsConfig::insecure_skip_verify())
+        .alpns(vec![ALPN.to_vec()])
+        .bind()
+        .await
+        .unwrap();
+    server_endpoint.online().await;
+    let server_addr = server_endpoint.addr();
+    let server_id = server_endpoint.id().to_string();
+
+    let client_endpoint = Endpoint::builder(presets::Minimal)
+        .relay_mode(RelayMode::Custom(relay_map))
+        .ca_tls_config(CaTlsConfig::insecure_skip_verify())
+        .alpns(vec![ALPN.to_vec()])
+        .bind()
+        .await
+        .unwrap();
+    let client_id = client_endpoint.id().to_string();
+
+    let accepting = {
+        let server_endpoint = server_endpoint.clone();
+        tokio::spawn(async move {
+            server_endpoint.accept().await.unwrap().await.unwrap()
+        })
+    };
+
+    let client_connection =
+        client_endpoint.connect(server_addr, ALPN).await.unwrap();
+    let server_connection = accepting.await.unwrap();
+
+    Pair {
+        client: IrohSession::new_owned(client_connection, client_endpoint),
+        server: IrohSession::new_owned(server_connection, server_endpoint),
+        client_id,
+        server_id,
+        _relay: Box::new(relay),
+    }
+}
+
+// r[impl jetstream.session.capabilities]
+#[tokio::test(flavor = "multi_thread")]
+async fn an_iroh_session_reports_its_row() {
+    let pair = pair().await;
+    let caps = Session::<TestProtocol>::capabilities(&pair.client);
+
+    assert_eq!(caps, Capabilities::iroh());
+    assert_eq!(caps.lanes, LaneSupport::Many);
+    assert!(caps.datagrams);
+    assert_eq!(caps.identity, IdentityKind::Key);
+    assert!(caps.migration);
+
+    // r[impl jetstream.session.identity.addressing]
+    // The key is the address, so a caller never has to carry placement
+    // information alongside it.
+    assert!(!caps.identity.requires_address());
+}
+
+// r[impl jetstream.lane.independence]
+#[tokio::test(flavor = "multi_thread")]
+async fn each_lane_is_its_own_stream() {
+    let pair = pair().await;
+
+    let mut first = pair.client.open_lane().await.unwrap();
+    let mut second = pair.client.open_lane().await.unwrap();
+
+    // A QUIC stream reaches the peer on its first write, so both lanes
+    // are announced before either is accepted.
+    first.send(frame(1, "first")).await.unwrap();
+    second.send(frame(2, "second")).await.unwrap();
+
+    let mut served_first = pair.server.accept_lane().await.unwrap();
+    let mut served_second = pair.server.accept_lane().await.unwrap();
+
+    let got = served_first.next().await.unwrap().unwrap();
+    assert_eq!(got.msg.as_str(), "first");
+    let got = served_second.next().await.unwrap().unwrap();
+    assert_eq!(got.msg.as_str(), "second");
+
+    let quiet = timeout(Duration::from_millis(50), served_first.next()).await;
+    assert!(quiet.is_err(), "the first lane should be waiting");
+
+    // r[impl jetstream.session.symmetric]
+    served_second.send(frame(2, "answered")).await.unwrap();
+    let got = second.next().await.unwrap().unwrap();
+    assert_eq!(got.msg.as_str(), "answered");
+}
+
+// r[impl jetstream.session.identity]
+#[tokio::test(flavor = "multi_thread")]
+async fn both_ends_of_a_session_know_the_other() {
+    let pair = pair().await;
+
+    // iroh authenticates both peers during the handshake, so unlike a
+    // one-sided TLS connection the caller is named too.
+    let server_view = Session::<TestProtocol>::context(&pair.server);
+    let client_view = Session::<TestProtocol>::context(&pair.client);
+
+    assert!(matches!(server_view.peer(), Some(Peer::NodeId(_))));
+    assert!(matches!(client_view.peer(), Some(Peer::NodeId(_))));
+    assert_eq!(server_view.to_string(), pair.client_id);
+    assert_eq!(client_view.to_string(), pair.server_id);
+
+    // A lane carries the session's identity, so a handler reading only
+    // the lane sees the same peer.
+    let mut lane = pair.client.open_lane().await.unwrap();
+    lane.send(frame(1, "hello")).await.unwrap();
+    let served = pair.server.accept_lane().await.unwrap();
+    assert_eq!(Contextual::context(&served), server_view);
+}
+
+// r[impl jetstream.session.lifetime]
+#[tokio::test(flavor = "multi_thread")]
+async fn closing_a_session_terminates_its_lanes() {
+    let pair = pair().await;
+
+    let mut lane = pair.client.open_lane().await.unwrap();
+    lane.send(frame(1, "hello")).await.unwrap();
+    let mut served = pair.server.accept_lane().await.unwrap();
+    assert_eq!(served.next().await.unwrap().unwrap().msg.as_str(), "hello");
+
+    Session::<TestProtocol>::close(&pair.server).await;
+
+    let ended = timeout(Duration::from_secs(10), lane.next())
+        .await
+        .expect("the lane should have terminated, not hung");
+    assert!(
+        matches!(ended, Some(Err(_))),
+        "a lane on a closed session should fail, got {ended:?}"
+    );
+
+    let opened = timeout(Duration::from_secs(10), pair.client.open_lane())
+        .await
+        .expect("opening on a closed session should not hang");
+    assert!(opened.is_err(), "a closed session should not open a lane");
+}
+
+// r[impl jetstream.session.datagrams]
+#[tokio::test(flavor = "multi_thread")]
+async fn a_datagram_round_trips() {
+    let pair = pair().await;
+
+    pair.client
+        .send_datagram(frame(7, "unordered"))
+        .await
+        .unwrap();
+
+    let got = timeout(Duration::from_secs(10), pair.server.recv_datagram())
+        .await
+        .expect("the datagram should have arrived")
+        .unwrap();
+    assert_eq!(got.tag, 7);
+    assert_eq!(got.msg.as_str(), "unordered");
+}
+
+// r[impl jetstream.session.datagrams]
+#[tokio::test(flavor = "multi_thread")]
+async fn an_oversized_datagram_is_rejected_at_the_sender() {
+    let pair = pair().await;
+
+    let limit = Datagrams::<TestProtocol>::max_datagram_size(&pair.client)
+        .expect("iroh should report a datagram limit");
+
+    let too_big = Frame {
+        tag: 1,
+        msg: Blob::of(limit as usize + 1),
+    };
+    assert!(WireFormat::byte_size(&too_big) > limit);
+
+    match pair.client.send_datagram(too_big).await {
+        Err(SessionError::DatagramTooLarge { limit: got, .. }) => {
+            assert_eq!(got, limit)
+        }
+        other => panic!("expected DatagramTooLarge, got {other:?}"),
+    }
+}
+
+// r[impl jetstream.session.datagrams]
+#[tokio::test(flavor = "multi_thread")]
+async fn a_datagram_with_trailing_bytes_is_rejected() {
+    let pair = pair().await;
+
+    // A frame, then a byte that is not part of it. Decoding the prefix
+    // would succeed and hand back something the peer never sent.
+    let mut buf = Vec::new();
+    WireFormat::encode(&frame(3, "whole"), &mut buf).unwrap();
+    buf.push(0xff);
+
+    pair.client.connection().send_datagram(buf.into()).unwrap();
+
+    let got = timeout(Duration::from_secs(10), pair.server.recv_datagram())
+        .await
+        .expect("the datagram should have arrived");
+    assert!(
+        got.is_err(),
+        "a datagram with trailing bytes is not a complete frame"
+    );
+}

--- a/tests/iroh_session.rs
+++ b/tests/iroh_session.rs
@@ -91,9 +91,18 @@ async fn an_iroh_session_reports_its_row() {
 
     assert_eq!(caps, Capabilities::iroh());
     assert_eq!(caps.lanes, LaneSupport::Many);
-    assert!(caps.datagrams);
     assert_eq!(caps.identity, IdentityKind::Key);
     assert!(caps.migration);
+
+    // r[impl jetstream.session.capabilities.degradation]
+    // Datagrams are reported from the connection rather than from the
+    // row, so this asserts the peers actually negotiated them rather
+    // than that iroh supports them in principle.
+    assert!(caps.datagrams);
+    assert!(
+        Datagrams::<TestProtocol>::max_datagram_size(&pair.client).is_some(),
+        "the reported capability should match the connection"
+    );
 
     // r[impl jetstream.session.identity.addressing]
     // The key is the address, so a caller never has to carry placement

--- a/tests/iroh_session.rs
+++ b/tests/iroh_session.rs
@@ -206,10 +206,30 @@ async fn closing_a_session_terminates_its_lanes() {
         "a lane on a closed session should fail, got {ended:?}"
     );
 
+    // r[impl jetstream.session.lifetime]
+    // ...and says the session closed, rather than reporting a deliberate
+    // close as a transport fault. `Closed` is what a caller branches on
+    // to stop retrying.
     let opened = timeout(Duration::from_secs(10), pair.client.open_lane())
         .await
         .expect("opening on a closed session should not hang");
-    assert!(opened.is_err(), "a closed session should not open a lane");
+    assert!(
+        matches!(opened, Err(SessionError::Closed)),
+        "a peer's close should report Closed, got {:?}",
+        opened.err()
+    );
+
+    // The same from the end that called `close`, which iroh reports
+    // differently underneath — `LocallyClosed` rather than
+    // `ApplicationClosed`.
+    let opened = timeout(Duration::from_secs(10), pair.server.open_lane())
+        .await
+        .expect("opening on a closed session should not hang");
+    assert!(
+        matches!(opened, Err(SessionError::Closed)),
+        "our own close should report Closed, got {:?}",
+        opened.err()
+    );
 }
 
 // Regression: `IrohSession` held the connection directly, so dropping

--- a/tests/session_common/mod.rs
+++ b/tests/session_common/mod.rs
@@ -1,0 +1,68 @@
+//! A minimal protocol the session integration tests share.
+//!
+//! The session tests drive frames through lanes directly rather than
+//! going through a generated service, because what is under test is the
+//! session and lane machinery and not the code generator.
+
+use std::io::{self, Read, Write};
+
+use jetstream_rpc::{Error, Frame, Framer, Protocol};
+
+/// A message whose body is whatever bytes are put in it, so that a test
+/// can size a frame deliberately against a transport's datagram limit.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Blob(pub Vec<u8>);
+
+impl Blob {
+    /// A blob of `len` bytes, filled with a repeating pattern.
+    pub fn of(len: usize) -> Self {
+        Blob((0..len).map(|n| n as u8).collect())
+    }
+
+    /// The blob as text, for a readable assertion.
+    pub fn as_str(&self) -> &str {
+        std::str::from_utf8(&self.0).expect("blob is not utf-8")
+    }
+}
+
+impl Framer for Blob {
+    fn message_type(&self) -> u8 {
+        1
+    }
+
+    fn byte_size(&self) -> u32 {
+        self.0.len() as u32
+    }
+
+    fn encode<W: Write>(&self, writer: &mut W) -> io::Result<()> {
+        writer.write_all(&self.0)
+    }
+
+    fn decode<R: Read>(reader: &mut R, _ty: u8) -> io::Result<Self> {
+        // `Frame::decode` hands down a reader bounded to this frame's
+        // body, so reading it to the end reads exactly this message.
+        let mut buf = Vec::new();
+        reader.read_to_end(&mut buf)?;
+        Ok(Blob(buf))
+    }
+}
+
+#[derive(Debug)]
+pub struct TestProtocol;
+
+impl Protocol for TestProtocol {
+    type Error = Error;
+    type Request = Blob;
+    type Response = Blob;
+
+    const NAME: &'static str = "session-test";
+    const VERSION: &'static str = "dev";
+}
+
+/// A frame carrying `body`.
+pub fn frame(tag: u16, body: &str) -> Frame<Blob> {
+    Frame {
+        tag,
+        msg: Blob(body.as_bytes().to_vec()),
+    }
+}

--- a/tests/session_common/mod.rs
+++ b/tests/session_common/mod.rs
@@ -3,31 +3,71 @@
 //! The session tests drive frames through lanes directly rather than
 //! going through a generated service, because what is under test is the
 //! session and lane machinery and not the code generator.
+//!
+//! The request and response types are **deliberately distinct**, and
+//! each refuses to decode the other's message type. A protocol that used
+//! one type for both would let a session confuse the two directions and
+//! still pass every test here — which is how the datagram API shipped
+//! decoding a peer's requests as responses.
 
 use std::io::{self, Read, Write};
 
 use jetstream_rpc::{Error, Frame, Framer, Protocol};
 
-/// A message whose body is whatever bytes are put in it, so that a test
-/// can size a frame deliberately against a transport's datagram limit.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Blob(pub Vec<u8>);
+const ASK: u8 = 1;
+const SAY: u8 = 2;
 
-impl Blob {
-    /// A blob of `len` bytes, filled with a repeating pattern.
+/// What a caller sends. The body is whatever bytes are put in it, so
+/// that a test can size a frame deliberately against a transport's
+/// datagram limit.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Ask(pub Vec<u8>);
+
+/// What a callee sends back.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Say(pub Vec<u8>);
+
+/// `Frame::decode` hands down a reader bounded to this frame's body, so
+/// reading it to the end reads exactly this message.
+fn read_body<R: Read>(
+    reader: &mut R,
+    ty: u8,
+    expected: u8,
+    name: &str,
+) -> io::Result<Vec<u8>> {
+    if ty != expected {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("message type {ty} is not a {name}"),
+        ));
+    }
+    let mut buf = Vec::new();
+    reader.read_to_end(&mut buf)?;
+    Ok(buf)
+}
+
+impl Ask {
+    /// An ask of `len` bytes, filled with a repeating pattern.
     pub fn of(len: usize) -> Self {
-        Blob((0..len).map(|n| n as u8).collect())
+        Ask((0..len).map(|n| n as u8).collect())
     }
 
-    /// The blob as text, for a readable assertion.
+    /// The body as text, for a readable assertion.
     pub fn as_str(&self) -> &str {
-        std::str::from_utf8(&self.0).expect("blob is not utf-8")
+        std::str::from_utf8(&self.0).expect("body is not utf-8")
     }
 }
 
-impl Framer for Blob {
+impl Say {
+    /// The body as text, for a readable assertion.
+    pub fn as_str(&self) -> &str {
+        std::str::from_utf8(&self.0).expect("body is not utf-8")
+    }
+}
+
+impl Framer for Ask {
     fn message_type(&self) -> u8 {
-        1
+        ASK
     }
 
     fn byte_size(&self) -> u32 {
@@ -38,12 +78,26 @@ impl Framer for Blob {
         writer.write_all(&self.0)
     }
 
-    fn decode<R: Read>(reader: &mut R, _ty: u8) -> io::Result<Self> {
-        // `Frame::decode` hands down a reader bounded to this frame's
-        // body, so reading it to the end reads exactly this message.
-        let mut buf = Vec::new();
-        reader.read_to_end(&mut buf)?;
-        Ok(Blob(buf))
+    fn decode<R: Read>(reader: &mut R, ty: u8) -> io::Result<Self> {
+        read_body(reader, ty, ASK, "request").map(Ask)
+    }
+}
+
+impl Framer for Say {
+    fn message_type(&self) -> u8 {
+        SAY
+    }
+
+    fn byte_size(&self) -> u32 {
+        self.0.len() as u32
+    }
+
+    fn encode<W: Write>(&self, writer: &mut W) -> io::Result<()> {
+        writer.write_all(&self.0)
+    }
+
+    fn decode<R: Read>(reader: &mut R, ty: u8) -> io::Result<Self> {
+        read_body(reader, ty, SAY, "response").map(Say)
     }
 }
 
@@ -52,17 +106,25 @@ pub struct TestProtocol;
 
 impl Protocol for TestProtocol {
     type Error = Error;
-    type Request = Blob;
-    type Response = Blob;
+    type Request = Ask;
+    type Response = Say;
 
     const NAME: &'static str = "session-test";
     const VERSION: &'static str = "dev";
 }
 
-/// A frame carrying `body`.
-pub fn frame(tag: u16, body: &str) -> Frame<Blob> {
+/// A request frame carrying `body`.
+pub fn frame(tag: u16, body: &str) -> Frame<Ask> {
     Frame {
         tag,
-        msg: Blob(body.as_bytes().to_vec()),
+        msg: Ask(body.as_bytes().to_vec()),
+    }
+}
+
+/// A response frame carrying `body`.
+pub fn response(tag: u16, body: &str) -> Frame<Say> {
+    Frame {
+        tag,
+        msg: Say(body.as_bytes().to_vec()),
     }
 }


### PR DESCRIPTION
Stacked on #681 — review that one first; this diff is against its branch. #687 sits on top of this one and carries the remaining transports.

A draft implementation of the model that PR specifies: `jetstream_rpc::session` plus the iroh binding the spec singles out.

## The trait

```rust
#[async_trait]
pub trait Session<P: Protocol>: Send + Sync {
    type ClientLane: ClientTransport<P>;
    type ServiceLane: ServiceTransport<P>;

    fn capabilities(&self) -> Capabilities;
    fn context(&self) -> Context;
    async fn open_lane(&self) -> Result<Self::ClientLane, SessionError>;
    async fn accept_lane(&self) -> Result<Self::ServiceLane, SessionError>;
    async fn close(&self);
}
```

Two lane types rather than one plus a flag: the end that opens a lane is the caller on it (`r[jetstream.session.symmetric]`), so the direction is already in the type. Both methods take `&self`, so opening never needs exclusive access to the session (`r[jetstream.session.trait]`).

Nothing in `ClientTransport` or `ServiceTransport` changes. A lane is still a value satisfying them; what is new is a way to obtain one without naming the concrete transport (`r[jetstream.session.overview.additive]`).

`Capabilities` has a constructor per row of the conformance table, so a transport declares its row instead of assembling one, and `require` fails explicitly for a capability that is absent — silently emulating `Many` by interleaving on one stream is exactly what `r[jetstream.session.capabilities.degradation]` forbids.

## Implementations

| | Lanes | Datagrams | Identity | Notes |
| --- | --- | --- | --- | --- |
| `SingleLaneSession` | One | — | reported by caller | wraps an existing framed byte stream |
| `LocalSession` | Many | — | None | two peers in one process |
| `IrohSession` | Many | Yes | Key | a lane per `open_bi` |

- **`SingleLaneSession`** hands out its lane once. The second open fails with `LaneLimitReached`, which carries a stable code both as a `SessionError` and once converted to `Error`, rather than blocking or silently sharing the lane already in use. `NoClientLane`/`NoServiceLane` are uninhabited, so "this session accepts nothing" is a type rather than a runtime convention.
- **`LocalSession`** connects two in-process peers. Frames move as values — nothing is encoded to bytes to obtain ordering (`r[jetstream.session.local.no-serialisation]`). Each lane is its own channel pair, so lanes do not block each other, and the bounded channel is the backpressure.
- **`IrohSession`** exposes the `Connection` as a session, with QUIC datagrams behind a separate `Datagrams` trait (a datagram channel is not a lane, so it is not a `ClientTransport`). `client_builder` keeps its exact previous signature and behaviour; `session_builder` is the new path for callers that want more than one lane.

Lanes are returned wrapped in `LaneGuard`, which observes a token the session holds. That is what makes `close` reach a lane the caller already owns, so `r[jetstream.session.lifetime]` holds for both session types rather than only the in-process one.

## Order handoff

`LaneOrder` is the part worth arguing about. A ticket is taken synchronously where the order is decided, and delivery waits for its turn, so a lane written from several tasks keeps call-site order rather than admission order. A ticket dropped before delivering passes its place to the next frame rather than releasing it — that is what stops a later frame overtaking an earlier one still in flight (`r[jetstream.session.local.order-handoff]`).

This is celld's `CallOrder` generalised from per-callee to per-lane. Reconciling celld with it is not in this PR.

`LocalClientLane::ordered_sender` is the concurrent-producer path; the lane's own `Sink` is sequential and needs no ticket. Using both on one lane would defeat the point, and the docs say so — if that reads as too sharp an edge, the alternative is to make the ordered sender the only write path and drop the bare `Sink`.

## Review rounds

Four findings from `@codex` in the first round, all four real, fixed in 1120de1 and each with a regression test **checked to fail without its fix**:

| Finding | Fix |
| --- | --- |
| `close` was a no-op once the lane was handed out | session keeps a token per lane; lane wrapped in `LaneGuard` |
| Concurrent `accept_lane` could park forever on a lost notification | re-check `is_closed` under the offers lock |
| Lane tokens never reclaimed | prune dead entries on registration; `live_lanes()` reports what is alive |
| `client_builder` picked up a source-breaking `P::Error = Error` bound | reverted to `P: Protocol`, dials directly |

Writing the backpressure test then turned up a defect nobody had flagged: the in-process lane was built on `futures::channel::mpsc`, whose sender refuses **every later write** once a send future is dropped while pending — a lost `select!` arm or a write under a timeout would wedge the lane permanently. Reproduced against the bare channel to confirm it was not this code; the lane now writes through `tokio_util::sync::PollSender`, which holds the reservation across the drop.

## Tests

44, named after what they check and annotated against the requirements they exercise.

**37 in `jetstream_rpc`** over the in-process and single-lane sessions: delivery order, lane independence, session close terminating lanes in flight, the single-lane second open, capability refusal, key addressing, datagram size rejection, backpressure, cancelled writes, concurrent opens, per-lane order under interleaving, and the order handoff including abandonment scattered through the queue.

**7 in `tests/iroh_session.rs` over a real iroh handshake**, added in 363d35c: the conformance row, a lane per `open_bi` with the lanes shown independent, both ends naming the other by public key, a lane failing rather than hanging once the session closes, a datagram round trip, an oversized frame refused at the sender, and a datagram with trailing bytes refused as the incomplete frame it is. Two endpoints and `iroh::test_utils::run_relay_server`, so nothing reaches the public relay network.

> An earlier version of this description listed "no transport-backed integration test" under **Not done**, and said an iroh session test "needs a local endpoint pair the crate does not currently build". **That was wrong.** `tests/iroh.rs` has run against a local relay since before this work, with `iroh`'s `test-utils` feature already a dev-dependency — I reasoned from `endpoint_builder` dialling the real relay and never looked in `tests/`. Nothing was missing, so the two things a remote peer can actually reach — the lane lifetime and the datagram decode — went untested for no reason. They are covered now.

`cargo clippy -p jetstream_rpc -p jetstream_iroh --all-targets` is clean. `cargo check --workspace --all-targets --features iroh` surfaces only a pre-existing `syn`/`prettyplease` mismatch in `jetstream_macros` tests, present on `main` too and untouched here.

## Not done

- **No concurrency model checking.** The order handoff is where a race would hide, and thread-scheduling tests only sample interleavings. The crate already carries a `loom` dependency for `cfg(loom)`; putting `LaneOrder` under it is the honest way to cover this, and I have not done it. Note it is only a partial answer as things stand: loom has no shim for `tokio::sync::Notify`, so the ordering state machine would have to be split from the async wakeup before it can run under loom at all.
- **No property tests on ordering.** `proptest` is already a dev-dependency; randomised admission and abandonment schedules would beat hand-picked "every third", and would cost less than the loom split.
- Per-lane version negotiation (`r[jetstream.session.version-scope]`) is unchanged — nothing here scopes a `Tversion` reset to its lane yet.
- `r[jetstream.session.local.boundary]`, where an in-process lane meets a transport-backed one, is not implemented; it needs a router that knows about lanes.