### PR TITLE
feat(rpc): the wire pieces subscriptions need

### DIFF
--- a/components/jetstream_rpc/src/lib.rs
+++ b/components/jetstream_rpc/src/lib.rs
@@ -28,6 +28,7 @@ mod mux;
 mod router;
 pub mod server;
 pub mod session;
+pub mod subscription;
 mod tag;
 mod version;
 pub use any_server::AnyServer;

--- a/components/jetstream_rpc/src/subscription.rs
+++ b/components/jetstream_rpc/src/subscription.rs
@@ -43,7 +43,47 @@ pub struct Tcancel {
     /// where `oldtag` is unambiguous. Otherwise the binding identifier,
     /// because tags are allocated per lane and a concurrent subscription
     /// elsewhere on the session may hold the same number.
+    ///
+    /// Zero is **reserved** and never a real binding, which is what makes
+    /// the sentinel sound. Prefer [`Tcancel::on_lane`] and
+    /// [`Tcancel::off_lane`] over writing this field: the specification
+    /// used to recommend a counter starting at zero, so the first
+    /// subscription of a session got a binding indistinguishable from
+    /// "no binding" — and a receiver then resolved `oldtag` against the
+    /// wrong lane.
     pub binding: u64,
+}
+
+impl Tcancel {
+    /// Cancel a subscription on the lane this cancellation travels.
+    /// `oldtag` is unambiguous there, so no binding is named.
+    pub fn on_lane(oldtag: u16) -> Self {
+        Tcancel { oldtag, binding: 0 }
+    }
+
+    /// Cancel a subscription living on some *other* lane of the session,
+    /// naming it by its binding identifier.
+    ///
+    /// # Panics
+    ///
+    /// If `binding` is zero, which is reserved for the on-lane case.
+    /// A caller reaching this has allocated bindings from a counter
+    /// starting at zero — the allocation `r[jetstream.subscription.identity]`
+    /// now forbids for exactly this reason.
+    pub fn off_lane(oldtag: u16, binding: u64) -> Self {
+        assert_ne!(
+            binding, 0,
+            "binding identifier zero is reserved for the on-lane case; \
+             allocate bindings from one"
+        );
+        Tcancel { oldtag, binding }
+    }
+
+    /// The binding this names, or `None` when it is on the subscription's
+    /// own lane.
+    pub fn target_binding(&self) -> Option<u64> {
+        (self.binding != 0).then_some(self.binding)
+    }
 }
 
 /// r[impl jetstream.subscription.cancel]

--- a/components/jetstream_rpc/src/subscription.rs
+++ b/components/jetstream_rpc/src/subscription.rs
@@ -1,0 +1,86 @@
+//! Wire pieces for subscriptions.
+//!
+//! r[impl jetstream.subscription.overview]
+//! A subscription is a streaming response: one request, many responses
+//! sharing its tag, terminated explicitly. This module carries the three
+//! things that shape needs on the wire and nothing else — the terminator,
+//! cancellation, and the endpoint identifier. The client and server
+//! plumbing that uses them lands separately.
+
+use jetstream_wireformat::{Data, JetStreamWireFormat};
+
+/// r[impl jetstream.subscription.compat]
+/// The terminator, and cancellation, take **global** message ids in the
+/// space below `MESSAGE_ID_START`, exactly as `RJETSTREAMERROR` already
+/// does. That is what keeps `102 + 2 * index` intact: a streaming method
+/// costs no extra per-method id, so `r[jetstream.rpc.swift.message-ids]`
+/// and `r[jetstream.rpc.ts.message-ids]` do not change and no protocol is
+/// re-generated for its unary methods.
+///
+/// 5, 6 and 7 are taken by the error frames; 100 and 101 by version. 106
+/// and 107 are `TERROR`/`RERROR`, which overlap the generated ids for
+/// method index 2 — latent today, since nothing decodes an `ErrorFrame`
+/// on a service lane, but a reason to allocate here rather than there.
+pub const RDONE: u8 = 8;
+
+/// r[impl jetstream.subscription.cancel]
+pub const TCANCEL: u8 = 9;
+/// r[impl jetstream.subscription.cancel]
+pub const RCANCEL: u8 = TCANCEL + 1;
+
+/// r[impl jetstream.subscription.cancel]
+/// Cancellation bears a **fresh** tag and names its target in the
+/// payload, which is the shape 9P's `Tflush` uses and the one this
+/// specification adopted after an earlier draft got the mechanics
+/// backwards. Sending it under the subscription's own tag would put two
+/// calls under one correlation key while that tag is still in flight.
+#[derive(Debug, Clone, PartialEq, Eq, JetStreamWireFormat)]
+pub struct Tcancel {
+    /// The tag of the subscription being cancelled.
+    pub oldtag: u16,
+    /// r[impl jetstream.subscription.identity]
+    /// Zero when the cancellation travels on the subscription's own lane,
+    /// where `oldtag` is unambiguous. Otherwise the binding identifier,
+    /// because tags are allocated per lane and a concurrent subscription
+    /// elsewhere on the session may hold the same number.
+    pub binding: u64,
+}
+
+/// r[impl jetstream.subscription.cancel]
+/// The acknowledgement, which `r[jetstream.subscription.cancel]` requires
+/// to arrive on the subscription's own lane after every item already
+/// emitted there — that ordering is what makes the tag safe to reuse.
+#[derive(Debug, Clone, PartialEq, Eq, JetStreamWireFormat)]
+pub struct Rcancel {
+    /// The tag that has now stopped emitting.
+    pub oldtag: u16,
+}
+
+/// r[impl jetstream.lane.addressing]
+/// The endpoint a subscription addresses within a peer — the room, the
+/// object, the cell. An opaque byte string: codegen emits the client that
+/// carries it and cannot know an application's naming, so any structure
+/// is the application's to impose and no implementation's to interpret.
+#[derive(Debug, Clone, PartialEq, Eq, JetStreamWireFormat)]
+pub struct Endpoint(pub Data);
+
+impl Endpoint {
+    /// The endpoint naming nothing in particular: a peer that hosts one
+    /// thing, which is every protocol written before this existed.
+    pub fn root() -> Self {
+        Endpoint(Data(Vec::new()))
+    }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0 .0
+    }
+}
+
+impl From<&str> for Endpoint {
+    fn from(name: &str) -> Self {
+        Endpoint(Data(name.as_bytes().to_vec()))
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/components/jetstream_rpc/src/subscription/tests.rs
+++ b/components/jetstream_rpc/src/subscription/tests.rs
@@ -1,0 +1,61 @@
+use jetstream_wireformat::{wire_format_extensions::ConvertWireFormat, Data};
+
+use super::*;
+
+/// r[impl jetstream.subscription.compat]
+/// The point of the whole allocation: a streaming method costs no
+/// per-method id, so `102 + 2 * index` is untouched and the cross-language
+/// message-id rules do not change.
+#[test]
+fn the_new_ids_sit_below_the_per_method_space() {
+    for id in [RDONE, TCANCEL, RCANCEL] {
+        assert!(
+            id < 100,
+            "{id} must be below TVERSION, or it collides with a method"
+        );
+    }
+    for taken in [5u8, 6, 7] {
+        assert!(![RDONE, TCANCEL, RCANCEL].contains(&taken));
+    }
+    assert_ne!(RDONE, TCANCEL);
+    assert_ne!(TCANCEL, RCANCEL);
+}
+
+#[test]
+fn cancellation_round_trips() {
+    let t = Tcancel {
+        oldtag: 7,
+        binding: 0,
+    };
+    assert_eq!(Tcancel::from_bytes(&t.to_bytes()).unwrap(), t);
+
+    // r[impl jetstream.subscription.identity]
+    // Off-lane cancellation names the binding, because `oldtag` alone is
+    // ambiguous across lanes.
+    let off_lane = Tcancel {
+        oldtag: 7,
+        binding: u64::MAX,
+    };
+    assert_eq!(Tcancel::from_bytes(&off_lane.to_bytes()).unwrap(), off_lane);
+    assert_ne!(t, off_lane, "the binding must be part of the identity");
+
+    let r = Rcancel { oldtag: 7 };
+    assert_eq!(Rcancel::from_bytes(&r.to_bytes()).unwrap(), r);
+}
+
+/// r[impl jetstream.lane.addressing]
+#[test]
+fn an_endpoint_is_opaque_bytes() {
+    let room = Endpoint::from("room-42");
+    assert_eq!(room.as_bytes(), b"room-42");
+    assert_eq!(Endpoint::from_bytes(&room.to_bytes()).unwrap(), room);
+
+    let root = Endpoint::root();
+    assert!(root.as_bytes().is_empty());
+    assert_eq!(Endpoint::from_bytes(&root.to_bytes()).unwrap(), root);
+    assert_ne!(root, room);
+
+    // Nothing interprets the bytes: a name that is not UTF-8 is a name.
+    let binary = Endpoint(Data(vec![0xff, 0x00, 0xfe]));
+    assert_eq!(Endpoint::from_bytes(&binary.to_bytes()).unwrap(), binary);
+}

--- a/components/jetstream_rpc/src/subscription/tests.rs
+++ b/components/jetstream_rpc/src/subscription/tests.rs
@@ -2,6 +2,33 @@ use jetstream_wireformat::{wire_format_extensions::ConvertWireFormat, Data};
 
 use super::*;
 
+/// r[impl jetstream.subscription.identity]
+/// Zero is reserved, so an off-lane cancellation can never be mistaken
+/// for an on-lane one. The specification used to recommend a counter
+/// starting at zero, which made the first subscription of every session
+/// exactly that mistake.
+#[test]
+fn zero_is_not_a_binding() {
+    let on_lane = Tcancel::on_lane(7);
+    assert_eq!(on_lane.binding, 0);
+    assert_eq!(on_lane.target_binding(), None, "no binding is named");
+
+    let off_lane = Tcancel::off_lane(7, 1);
+    assert_eq!(off_lane.target_binding(), Some(1));
+    assert_ne!(
+        on_lane, off_lane,
+        "the first binding of a session must not encode as the on-lane form"
+    );
+}
+
+/// The allocation the specification used to bless, refused at the
+/// constructor rather than producing a cancellation nobody can route.
+#[test]
+#[should_panic(expected = "reserved for the on-lane case")]
+fn a_binding_counter_starting_at_zero_is_refused() {
+    let _ = Tcancel::off_lane(7, 0);
+}
+
 /// r[impl jetstream.subscription.compat]
 /// The point of the whole allocation: a streaming method costs no
 /// per-method id, so `102 + 2 * index` is untouched and the cross-language


### PR DESCRIPTION
First of the implementation stack on #694. Stacked on the spec branch; review #694 first.

Deliberately the smallest thing that settles the riskiest question in the plan.

## The message-id space was the big risk, and it costs nothing

The concern was that a streaming method needs a third message per method — item, end, error — while the macro assigns exactly two, `102 + 2 * index`. If that were true, `r[jetstream.rpc.swift.message-ids]` and `r[jetstream.rpc.ts.message-ids]` both hard-code the scheme, so **three specifications would have had to change together**.

They don't. `RJETSTREAMERROR = 5` is already a *global* id rather than a per-method one, and that is the precedent: `RDONE`, `TCANCEL` and `RCANCEL` take global ids below `MESSAGE_ID_START`, the per-method space is untouched, and no protocol is re-generated for its unary methods.

The test asserts the *property*, not the constants, so it fails if someone later allocates into the per-method space:

```rust
for id in [RDONE, TCANCEL, RCANCEL] {
    assert!(id < 100, "{id} must be below TVERSION, or it collides with a method");
}
```

Noted in the module docs rather than silently avoided: `TERROR = 106` and `RERROR = 107` overlap the generated ids for method index 2. Latent today — nothing decodes an `ErrorFrame` on a service lane — but a reason to allocate low rather than high.

## `Tcancel` carries what two corrections established it needs

```rust
pub struct Tcancel {
    pub oldtag: u16,
    pub binding: u64,
}
```

A fresh tag naming its target, which is 9P's `Tflush` shape — the spec's first draft had this backwards and sent cancellation under the subscription's own tag, putting two calls under one correlation key. Plus the binding identifier for the off-lane case: tags are allocated per lane (`TagPool` lives inside `Mux::new`), so `oldtag` alone is ambiguous across a session. Zero means the cancellation travels on the subscription's own lane, where the tag suffices.

## `Endpoint` came from writing the usage, not reading the spec

```rust
pub struct Endpoint(pub Data);
```

`RoomChannel::over(session, RoomId("room-42"))` would not compile without inventing a type — and `#[service]` generates the client that carries the endpoint, so it cannot know an application's naming. Opaque bytes, with `Endpoint::root()` for a peer that hosts one thing, which is every protocol written before this existed.

## Scope

Wire only. Client streaming (`RpcCall` is a `oneshot` today, and `Mux::demux` panics on an unknown tag) and the server dispatch path land separately, each with its own tests.

3 new tests, all passing; 51 in `jetstream_rpc` overall. `cargo clippy -p jetstream_rpc --all-targets` clean apart from a pre-existing warning in `jetstream_wireformat`. Workspace builds with `--all-features`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017u7J4fStrsu5W6CoXSw11t

---
_Generated by [Claude Code](https://claude.ai/code/session_017u7J4fStrsu5W6CoXSw11t)_