### PR TITLE
feat(rpc): serve subscriptions, with cancellation reaching the producer

### DIFF
--- a/components/jetstream_rpc/Cargo.toml
+++ b/components/jetstream_rpc/Cargo.toml
@@ -22,7 +22,9 @@ thiserror = "2.0.17"
 url = { workspace = true }
 iroh = { workspace = true, optional = true }
 turmoil = { workspace = true, optional = true }
-tokio = { version = "1.47.1", features = ["sync", "rt"] }
+# `macros` for `select!`: the dispatcher serves subscriptions
+# concurrently with the requests still arriving on the lane.
+tokio = { version = "1.47.1", features = ["sync", "rt", "macros"] }
 async-trait = "0.1.89"
 serde = { version = "1.0.228", features = ["derive"], optional = true }
 jetstream_error = { version = "16.2.0", path = "../jetstream_error" }

--- a/components/jetstream_rpc/src/call.rs
+++ b/components/jetstream_rpc/src/call.rs
@@ -82,7 +82,7 @@ pub struct RpcStream<P: Protocol> {
     /// synchronous: building the cancellation needs nothing async, but
     /// *sending* it needs a tag of its own, and acquiring one may wait.
     /// The `Mux`'s cancellation task does the waiting.
-    pub(crate) cancels: tokio::sync::mpsc::Sender<u16>,
+    pub(crate) cancels: tokio::sync::mpsc::UnboundedSender<u16>,
     /// Whether the terminator has already arrived. A subscription that
     /// ended has nothing to cancel, and cancelling it anyway costs a tag
     /// and a round trip on every completed subscription.
@@ -141,7 +141,7 @@ impl<P: Protocol> Drop for RpcStream<P> {
         if self.finished {
             return;
         }
-        if self.cancels.try_send(self.tag).is_err() {
+        if self.cancels.send(self.tag).is_err() {
             // The client is shutting down, or more subscriptions were
             // dropped at once than the queue holds. The producer learns
             // when the lane closes, which is the same conclusion by a

--- a/components/jetstream_rpc/src/call.rs
+++ b/components/jetstream_rpc/src/call.rs
@@ -2,7 +2,7 @@ use std::future::Future;
 
 use futures::FutureExt;
 
-use crate::{Frame, Protocol};
+use crate::{Frame, Framer, Protocol};
 
 pub struct RpcCall<P: Protocol> {
     pub tag: u16,
@@ -76,6 +76,17 @@ pub struct RpcStream<P: Protocol> {
         jetstream_error::Result<Frame<P::Response>>,
     >,
     pub(crate) in_flight: crate::mux::InFlight<P>,
+    /// Where a dropped subscription's tag goes to be cancelled.
+    ///
+    /// A `u16` rather than a built request, because `Drop` is
+    /// synchronous: building the cancellation needs nothing async, but
+    /// *sending* it needs a tag of its own, and acquiring one may wait.
+    /// The `Mux`'s cancellation task does the waiting.
+    pub(crate) cancels: tokio::sync::mpsc::Sender<u16>,
+    /// Whether the terminator has already arrived. A subscription that
+    /// ended has nothing to cancel, and cancelling it anyway costs a tag
+    /// and a round trip on every completed subscription.
+    pub(crate) finished: bool,
 }
 
 impl<P: Protocol> futures::Stream for RpcStream<P> {
@@ -85,7 +96,20 @@ impl<P: Protocol> futures::Stream for RpcStream<P> {
         mut self: std::pin::Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Option<Self::Item>> {
-        self.items.poll_recv(cx)
+        let polled = self.items.poll_recv(cx);
+        // r[impl jetstream.subscription.termination]
+        if let std::task::Poll::Ready(end) = &polled {
+            self.finished = match end {
+                Some(Ok(frame)) => {
+                    frame.msg.message_type() == crate::subscription::RDONE
+                }
+                // An error item, or the channel closed under us: either
+                // way no terminator is coming and there is nothing left
+                // to cancel.
+                _ => true,
+            };
+        }
+        polled
     }
 }
 
@@ -105,6 +129,24 @@ impl<P: Protocol> Drop for RpcStream<P> {
             if let Some(slot) = map.get_mut(&self.tag) {
                 *slot = crate::mux::Waiter::Abandoned;
             }
+        }
+
+        // r[impl jetstream.subscription.surface.cancellation]
+        // r[impl jetstream.subscription.cancel]
+        // Marking the tag abandoned only stops *delivery*. The producer
+        // is still working, and cancellation is required to reach the
+        // work — so the drop a Rust caller uses to cancel has to send the
+        // cancellation, not merely stop reading. Without this the rule
+        // was unimplemented end to end: the service never heard.
+        if self.finished {
+            return;
+        }
+        if self.cancels.try_send(self.tag).is_err() {
+            // The client is shutting down, or more subscriptions were
+            // dropped at once than the queue holds. The producer learns
+            // when the lane closes, which is the same conclusion by a
+            // slower route.
+            tracing::debug!(tag = self.tag, "cancellation not queued");
         }
     }
 }

--- a/components/jetstream_rpc/src/lib.rs
+++ b/components/jetstream_rpc/src/lib.rs
@@ -31,6 +31,8 @@ pub mod session;
 pub mod subscription;
 mod tag;
 mod version;
+use std::str::FromStr;
+
 pub use any_server::AnyServer;
 pub use call::*;
 pub use constants::*;
@@ -39,7 +41,6 @@ pub use jetstream_error::IntoError;
 use jetstream_wireformat::WireFormat;
 pub use mux::*;
 pub use router::*;
-use std::str::FromStr;
 pub use tag::*;
 pub use tokio_util::codec::{Decoder, Encoder, Framed};
 pub use version::*;
@@ -90,6 +91,26 @@ pub trait Protocol: Send + Sync {
     type Error: IntoError;
     const VERSION: &'static str;
     const NAME: &'static str;
+
+    /// r[impl jetstream.subscription.cancel]
+    /// The cancellation request for a subscription on this lane, if this
+    /// protocol has subscriptions to cancel.
+    ///
+    /// The client needs to *build* a request it cannot name: `Mux` is
+    /// generic over the protocol, and `subscription::Tcancel` is a
+    /// payload, not a `Request`. Only the protocol knows how one is
+    /// carried in its own request type, so it says here.
+    ///
+    /// r[impl jetstream.subscription.compat.rpc-layer]
+    /// Defaulted to `None` — a protocol with no streaming methods has
+    /// nothing to cancel, and every protocol written before this existed
+    /// compiles untouched.
+    ///
+    /// `binding` is zero on the subscription's own lane, where `oldtag`
+    /// is unambiguous; see `subscription::Tcancel`.
+    fn tcancel(_oldtag: u16, _binding: u64) -> Option<Self::Request> {
+        None
+    }
 }
 
 // const _: () = {

--- a/components/jetstream_rpc/src/mux.rs
+++ b/components/jetstream_rpc/src/mux.rs
@@ -49,6 +49,18 @@ pub struct Mux<P: Protocol> {
     send_queue: tokio::sync::mpsc::Sender<Frame<P::Request>>,
     in_flight: InFlight<P>,
     tag_pool: Arc<TagPool>,
+    /// r[impl jetstream.subscription.cancel]
+    /// Tags of subscriptions whose caller has gone, awaiting a
+    /// cancellation on the wire.
+    ///
+    /// Unbounded, and that is deliberate. A bounded queue here is filled
+    /// by dropping enough unfinished subscriptions without yielding —
+    /// trivial on a single-threaded runtime — and the drop path cannot
+    /// wait, so the overflow is *discarded*: those subscriptions stay
+    /// `Abandoned`, their producers keep working, and their tags are
+    /// never released. Teardown has to be lossless, and this is bounded
+    /// in practice by the number of live subscriptions anyway.
+    cancels: mpsc::UnboundedSender<u16>,
 }
 
 impl<P: Protocol> Mux<P>
@@ -59,6 +71,7 @@ where
         mut rx: RxStream<P>,
         in_flight: InFlight<P>,
         tag_pool: Arc<TagPool>,
+        cancels: mpsc::UnboundedSender<u16>,
     ) -> Result<()> {
         use futures::StreamExt;
         // Why the lane stopped, so the drain below can tell every
@@ -174,10 +187,10 @@ where
                             tokio::spawn(async move {
                                 let _ = tx.send(Err(overflowed)).await;
                             });
-                            // Telling the *producer* to stop needs the
-                            // cancellation path, which arrives with the
-                            // dispatcher; until then this ends the
-                            // subscriber's side only.
+                            // r[impl jetstream.subscription.cancel]
+                            // And tell the producer, so the work stops
+                            // rather than only the delivery.
+                            let _ = cancels.send(tag);
                             continue;
                         }
                     }
@@ -274,6 +287,44 @@ where
         RpcCall { tag, future }
     }
 
+    /// r[impl jetstream.subscription.cancel]
+    /// Turns a dropped subscription's tag into a cancellation on the
+    /// wire.
+    ///
+    /// This is a task rather than something `Drop` does itself because
+    /// the cancellation needs a *fresh* tag — the specification forbids
+    /// reusing the subscription's own — and acquiring one may wait,
+    /// which a synchronous `Drop` cannot.
+    async fn cancel_dropped(
+        mut cancels: mpsc::UnboundedReceiver<u16>,
+        in_flight: InFlight<P>,
+        tag_pool: Arc<TagPool>,
+        send_queue: mpsc::Sender<Frame<P::Request>>,
+    ) {
+        while let Some(oldtag) = cancels.recv().await {
+            // Zero: the cancellation travels the subscription's own lane,
+            // where `oldtag` is unambiguous.
+            let Some(msg) = P::tcancel(oldtag, 0) else {
+                continue;
+            };
+            // r[impl jetstream.subscription.cancel]
+            // Control capacity, not the ordinary pool. Taking an ordinary
+            // tag here deadlocks precisely when cancellation matters:
+            // with the pool saturated by live subscriptions, this waits
+            // for a tag that is only released by the terminator this
+            // cancellation would produce.
+            let tag = tag_pool.acquire_control_tag().await;
+            // A unary waiter whose receiver is dropped: nobody is left to
+            // read the acknowledgement, but the tag must stay held until
+            // it arrives, and that is what the unary path already does.
+            let (tx, _rx) = oneshot::channel();
+            in_flight.lock().await.insert(tag, Waiter::Unary(tx));
+            if send_queue.send(Frame { tag, msg }).await.is_err() {
+                break;
+            }
+        }
+    }
+
     pub fn new(
         max_concurrent_requests: u16,
         transport: Box<dyn ClientTransport<P>>,
@@ -285,12 +336,23 @@ where
         let in_flight = Arc::new(Mutex::new(BTreeMap::new()));
         let pending = in_flight.clone();
         let tags = tag_pool.clone();
-        tokio::spawn(async move { Self::demux(rx, pending, tags).await });
+        let (cancels, cancels_rx) = mpsc::unbounded_channel();
+        let lagged = cancels.clone();
+        tokio::spawn(
+            async move { Self::demux(rx, pending, tags, lagged).await },
+        );
         tokio::spawn(async move { Self::mux(send_queue_rx, tx).await });
+
+        let map = in_flight.clone();
+        let tags = tag_pool.clone();
+        let queue = send_queue.clone();
+        tokio::spawn(Self::cancel_dropped(cancels_rx, map, tags, queue));
+
         Self {
             in_flight,
             send_queue,
             tag_pool,
+            cancels,
         }
     }
 
@@ -332,6 +394,8 @@ where
             tag,
             items,
             in_flight: self.in_flight.clone(),
+            cancels: self.cancels.clone(),
+            finished: false,
         }
     }
 }

--- a/components/jetstream_rpc/src/mux/tests.rs
+++ b/components/jetstream_rpc/src/mux/tests.rs
@@ -342,8 +342,7 @@ async fn a_subscriber_that_stops_reading_does_not_stall_the_lane() {
     // The lane must still serve somebody else, promptly. Before this fix
     // the demultiplexer was parked awaiting the channel above and this
     // timed out.
-    let mut healthy =
-        mux.rpc_stream(Context::default(), Ask::Task(2), 8).await;
+    let mut healthy = mux.rpc_stream(Context::default(), Ask::Task(2), 8).await;
     let first =
         tokio::time::timeout(std::time::Duration::from_secs(5), healthy.next())
             .await
@@ -926,5 +925,154 @@ async fn a_finished_subscription_sends_no_cancellation() {
         .await
         .is_err(),
         "a subscription that already ended needs no cancelling"
+    );
+}
+
+/// r[impl jetstream.subscription.dispatch.concurrent]
+/// A producer that is always ready must not starve the inbound side.
+///
+/// The loop was `biased` with items first, reasoning that a ready
+/// producer should not wait behind an inbound request. That is exactly
+/// backwards: a producer which is ready on every poll — no timer, no
+/// awaited source, which `unfold` over a counter already is — means the
+/// item branch wins every time and the inbound branch is never selected.
+/// The chatty subscription then prevents *its own* cancellation from
+/// being read, which is the failure the whole dispatcher exists to
+/// remove, reintroduced as an optimisation.
+///
+/// The assertion is on *promptness*, not eventual delivery: with the
+/// biased loop the acknowledgement does arrive, after every one of the
+/// items ahead of it, and a test that merely waited would pass.
+#[tokio::test]
+async fn a_chatty_producer_does_not_starve_its_own_cancellation() {
+    let (to_service, service_rx) = fmpsc::unbounded();
+    let (service_tx, mut from_service) = fmpsc::unbounded();
+
+    tokio::spawn(async move {
+        let mut room = Room {
+            stopped: Default::default(),
+        };
+        let _ = crate::server::run(
+            &mut room,
+            ServiceSide {
+                tx: service_tx,
+                rx: service_rx,
+            },
+        )
+        .await;
+    });
+
+    // Long enough to starve the inbound branch for the length of the
+    // test, bounded so a regression fails rather than exhausts memory.
+    to_service
+        .unbounded_send(Ok(Frame {
+            tag: 1,
+            msg: Ask::Task(200_000),
+        }))
+        .unwrap();
+    to_service
+        .unbounded_send(Ok(Frame {
+            tag: 2,
+            msg: Ask::Cancel(crate::subscription::Tcancel::on_lane(1)),
+        }))
+        .unwrap();
+
+    // How many frames pass before the cancellation is answered. Under
+    // the biased loop this is every item the producer had queued.
+    let mut before = 0usize;
+    let acknowledged =
+        tokio::time::timeout(std::time::Duration::from_secs(10), async {
+            while let Some(Ok(frame)) = from_service.next().await {
+                if matches!(frame.msg, Say::Ack(_)) {
+                    return true;
+                }
+                before += 1;
+                if before > 5_000 {
+                    return false;
+                }
+            }
+            false
+        })
+        .await
+        .expect("the dispatcher must answer a cancellation at all");
+    assert!(
+        acknowledged,
+        "the cancellation went unanswered for {before} items: a producer \
+         that is always ready starved the inbound branch"
+    );
+}
+
+/// r[impl jetstream.subscription.cancel]
+/// A cancellation draws from control capacity, not the ordinary pool.
+///
+/// The specification requires this and the first implementation ignored
+/// it. The deadlock it prevents: a cancellation needs a *fresh* tag, the
+/// subscription's own tag is not released until its terminator, and the
+/// terminator cannot arrive until the cancellation is sent — so with the
+/// pool saturated by live subscriptions, cancellation waits on the very
+/// thing it would unblock.
+///
+/// Asserted on the tag's *region* rather than by reproducing the
+/// deadlock, because a test that hangs on regression is worse than one
+/// that fails: it takes the suite with it.
+#[tokio::test]
+async fn a_cancellation_uses_control_capacity() {
+    let (to_service, mut service_rx) = fmpsc::unbounded();
+    let (service_tx, from_service) = fmpsc::unbounded();
+    let mux = Mux::<Room>::new(
+        1,
+        Box::new(Duplex {
+            tx: to_service,
+            rx: from_service,
+        }),
+    );
+    drop(service_tx);
+
+    // One subscription, then let it go.
+    let items = mux.rpc_stream(Context::default(), Ask::Task(0), 8).await;
+    let subscribe = tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        service_rx.next(),
+    )
+    .await
+    .expect("the subscription reaches the lane")
+    .expect("a frame")
+    .expect("a well-formed frame");
+    drop(items);
+
+    let cancel = tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        service_rx.next(),
+    )
+    .await
+    .expect("dropping a subscription must produce a cancellation")
+    .expect("a frame")
+    .expect("a well-formed frame");
+
+    match cancel.msg {
+        Ask::Cancel(t) => {
+            assert_eq!(t.oldtag, subscribe.tag, "it names the subscription");
+            assert_eq!(
+                t.target_binding(),
+                None,
+                "on the subscription's own lane, so no binding is named"
+            );
+        }
+        other => panic!("expected a cancellation, got {other:?}"),
+    }
+
+    // `TagPool::new(1)` gives ordinary `1..=1`, then a streaming region,
+    // then control. The cancellation's own tag must come from the last of
+    // those: above the subscription's, and far above the ordinary one.
+    assert!(
+        cancel.tag > subscribe.tag,
+        "the cancellation's tag ({}) must come from a region above the \
+         streaming one ({})",
+        cancel.tag,
+        subscribe.tag
+    );
+    assert!(
+        cancel.tag > 1,
+        "and never from the ordinary pool, which is what deadlocks"
     );
 }

--- a/components/jetstream_rpc/src/mux/tests.rs
+++ b/components/jetstream_rpc/src/mux/tests.rs
@@ -21,6 +21,10 @@ use crate::{
     Error, Frame, Framer, Mux, Protocol,
 };
 
+/// A quiet room that takes its time shutting down. See
+/// `async_stream_items`.
+const LINGER: u32 = u32::MAX;
+
 const TASK: u8 = 102;
 const RITEM: u8 = 103;
 
@@ -475,11 +479,19 @@ fn async_stream_items(
                 stopped.store(true, std::sync::atomic::Ordering::SeqCst);
                 return None;
             }
-            if n == 0 {
+            if n == 0 || n == LINGER {
                 // The quiet room. It has nothing to say until something
                 // stops it, which is the shape a chat room, a build log
                 // between lines, or a presence feed actually has.
                 cancel.cancelled().await;
+                if n == LINGER {
+                    // And this one is slow to act on it, so a second
+                    // cancellation for the same subscription reaches the
+                    // dispatcher while the first is still open. Without
+                    // the delay that ordering is a race.
+                    tokio::time::sleep(std::time::Duration::from_millis(200))
+                        .await;
+                }
                 stopped.store(true, std::sync::atomic::Ordering::SeqCst);
                 return None;
             }
@@ -1288,4 +1300,53 @@ async fn dropping_a_finished_stream_leaves_a_reused_tag_alone() {
         "a stale stream abandoned a tag it no longer owned, silencing the \
          subscription that had taken it",
     );
+}
+
+/// r[verify jetstream.subscription.cancel]
+/// Every cancellation is owed an acknowledgement, including the second
+/// one for a subscription that has not finished stopping. Each arrives
+/// under its own tag, and that tag stays in flight until it is answered
+/// — so a forgotten acknowledgement is a control tag held for the life
+/// of the lane, and the client's own drop path can queue one of these
+/// behind a caller's.
+#[tokio::test]
+async fn two_cancellations_for_one_subscription_are_both_acknowledged() {
+    let (mux, _stopped) = wired();
+    let lingering = mux
+        .rpc_stream(Context::default(), Ask::Task(LINGER), 8)
+        .await;
+    let tag = lingering.tag;
+
+    // Both queued before the producer finishes stopping, so the
+    // dispatcher sees the second while the first is still recorded.
+    let first = mux
+        .rpc(
+            Context::default(),
+            Ask::Cancel(Tcancel {
+                oldtag: tag,
+                binding: 0,
+            }),
+        )
+        .await;
+    let second = mux
+        .rpc(
+            Context::default(),
+            Ask::Cancel(Tcancel {
+                oldtag: tag,
+                binding: 0,
+            }),
+        )
+        .await;
+
+    let (a, b) = tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        futures::future::join(first, second),
+    )
+    .await
+    .expect(
+        "both cancellations must be acknowledged; keeping only the latest \
+         strands the other's tag",
+    );
+    assert_eq!(a.unwrap().msg, Say::Ack(Rcancel { oldtag: tag }));
+    assert_eq!(b.unwrap().msg, Say::Ack(Rcancel { oldtag: tag }));
 }

--- a/components/jetstream_rpc/src/mux/tests.rs
+++ b/components/jetstream_rpc/src/mux/tests.rs
@@ -329,3 +329,286 @@ async fn a_subscriber_that_stops_reading_does_not_stall_the_lane() {
         "the reason must name the cause: {message}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// The server half, and then both halves against each other.
+
+/// A room that answers `Ask(n)` with `n` items and a terminator, and
+/// notices when the subscriber goes away.
+#[derive(Clone)]
+struct Room {
+    /// Set when the producer observed cancellation, which is what
+    /// `r[jetstream.subscription.cancel]` requires and what a `Sender`
+    /// alone could never provide.
+    stopped: std::sync::Arc<std::sync::atomic::AtomicBool>,
+}
+
+impl Protocol for Room {
+    type Error = Error;
+    type Request = Ask;
+    type Response = Say;
+
+    const NAME: &'static str = "room";
+    const VERSION: &'static str = "rs.jetstream.proto/room/0.0.0-test";
+}
+
+impl crate::server::Server for Room {
+    // r[impl jetstream.subscription.surface.declared]
+    fn is_streaming(message_type: u8) -> bool {
+        message_type == TASK
+    }
+
+    async fn rpc(
+        &mut self,
+        _ctx: Context,
+        _frame: Frame<Ask>,
+    ) -> Result<Frame<Say>, Error> {
+        Err(Error::new("this protocol has only a streaming method"))
+    }
+
+    async fn rpc_stream(
+        &mut self,
+        _ctx: Context,
+        frame: Frame<Ask>,
+        cancel: tokio_util::sync::CancellationToken,
+    ) -> crate::server::ResponseStream<Self> {
+        let Frame { tag, msg: Ask(n) } = frame;
+        let stopped = self.stopped.clone();
+        // Note the asymmetry with the trait's *default* body, which must
+        // be a bare `async move { .. }` block: `#[trait_variant::make]`
+        // rewrites the trait, not its implementations, so here an
+        // ordinary `async fn` body is exactly right.
+        Box::pin(async_stream_items(tag, n, cancel, stopped))
+    }
+}
+
+fn async_stream_items(
+    tag: u16,
+    n: u32,
+    cancel: tokio_util::sync::CancellationToken,
+    stopped: std::sync::Arc<std::sync::atomic::AtomicBool>,
+) -> impl Stream<Item = Result<Frame<Say>, Error>> + Send {
+    futures::stream::unfold(0u32, move |i| {
+        let cancel = cancel.clone();
+        let stopped = stopped.clone();
+        async move {
+            // r[impl jetstream.subscription.cancel]
+            // The producer watches for cancellation between items, which
+            // is the whole point of it being a parameter.
+            if cancel.is_cancelled() {
+                stopped.store(true, std::sync::atomic::Ordering::SeqCst);
+                return None;
+            }
+            if i < n {
+                Some((
+                    Ok(Frame {
+                        tag,
+                        msg: Say::Item(i),
+                    }),
+                    i + 1,
+                ))
+            } else if i == n {
+                Some((
+                    Ok(Frame {
+                        tag,
+                        msg: Say::Done,
+                    }),
+                    i + 1,
+                ))
+            } else {
+                None
+            }
+        }
+    })
+}
+
+/// r[impl jetstream.subscription.overview]
+/// The server half: one request in, many responses out, terminated.
+#[tokio::test]
+async fn a_service_serves_a_subscription() {
+    use crate::server::Server;
+
+    let mut room = Room {
+        stopped: Default::default(),
+    };
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let items = room
+        .rpc_stream(
+            Context::default(),
+            Frame {
+                tag: 3,
+                msg: Ask(4),
+            },
+            cancel,
+        )
+        .await;
+
+    let got: Vec<Say> = items.map(|i| i.unwrap().msg).collect().await;
+    assert_eq!(
+        got,
+        vec![
+            Say::Item(0),
+            Say::Item(1),
+            Say::Item(2),
+            Say::Item(3),
+            Say::Done
+        ]
+    );
+}
+
+/// r[impl jetstream.subscription.cancel]
+/// Cancellation reaches the *work*, not just the delivery. This is the
+/// finding that a `Sender`-only producer surface could not satisfy: the
+/// room stops producing rather than producing into a void.
+#[tokio::test]
+async fn cancellation_reaches_the_producer() {
+    use crate::server::Server;
+
+    let mut room = Room {
+        stopped: Default::default(),
+    };
+    let stopped = room.stopped.clone();
+    let cancel = tokio_util::sync::CancellationToken::new();
+
+    let mut items = room
+        .rpc_stream(
+            Context::default(),
+            Frame {
+                tag: 1,
+                msg: Ask(1_000_000),
+            },
+            cancel.clone(),
+        )
+        .await;
+
+    assert_eq!(items.next().await.unwrap().unwrap().msg, Say::Item(0));
+    assert!(!stopped.load(std::sync::atomic::Ordering::SeqCst));
+
+    cancel.cancel();
+    assert!(
+        items.next().await.is_none(),
+        "a cancelled producer stops emitting"
+    );
+    assert!(
+        stopped.load(std::sync::atomic::Ordering::SeqCst),
+        "the producer must observe cancellation, not merely be ignored"
+    );
+}
+
+/// r[impl jetstream.subscription.compat.existing-clients]
+/// `is_streaming` defaults to false, so a protocol written before this
+/// existed routes every request to `rpc` exactly as it did.
+#[tokio::test]
+async fn a_protocol_without_streaming_methods_is_unchanged() {
+    assert!(!<Counting as crate::server::Server>::is_streaming(TASK));
+}
+
+impl crate::server::Server for Counting {
+    async fn rpc(
+        &mut self,
+        _ctx: Context,
+        frame: Frame<Ask>,
+    ) -> Result<Frame<Say>, Error> {
+        Ok(Frame {
+            tag: frame.tag,
+            msg: Say::Item(frame.msg.0),
+        })
+    }
+}
+
+/// The service side of a duplex, so `server::run` can be driven.
+struct ServiceSide {
+    tx: fmpsc::UnboundedSender<Result<Frame<Say>, Error>>,
+    rx: fmpsc::UnboundedReceiver<Result<Frame<Ask>, Error>>,
+}
+impl Sink<Frame<Say>> for ServiceSide {
+    type Error = Error;
+
+    fn poll_ready(
+        self: Pin<&mut Self>,
+        _cx: &mut Cx<'_>,
+    ) -> Poll<Result<(), Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn start_send(self: Pin<&mut Self>, item: Frame<Say>) -> Result<(), Error> {
+        self.tx
+            .unbounded_send(Ok(item))
+            .map_err(|e| Error::new(e.to_string()))
+    }
+
+    fn poll_flush(
+        self: Pin<&mut Self>,
+        _cx: &mut Cx<'_>,
+    ) -> Poll<Result<(), Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_close(
+        self: Pin<&mut Self>,
+        _cx: &mut Cx<'_>,
+    ) -> Poll<Result<(), Error>> {
+        Poll::Ready(Ok(()))
+    }
+}
+impl Stream for ServiceSide {
+    type Item = Result<Frame<Ask>, Error>;
+
+    fn poll_next(
+        mut self: Pin<&mut Self>,
+        cx: &mut Cx<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        Pin::new(&mut self.rx).poll_next(cx)
+    }
+}
+impl crate::context::Contextual for ServiceSide {
+    fn context(&self) -> Context {
+        Context::default()
+    }
+}
+
+/// r[impl jetstream.subscription.surface.declared]
+/// The dispatcher routes on the declared message type. Without that
+/// routing every request goes to `rpc`, which this protocol answers with
+/// an error — so this test is what holds `run`'s streaming branch honest.
+#[tokio::test]
+async fn the_dispatcher_routes_a_streaming_request() {
+    let (to_service, service_rx) = fmpsc::unbounded();
+    let (service_tx, mut from_service) = fmpsc::unbounded();
+
+    tokio::spawn(async move {
+        let mut room = Room {
+            stopped: Default::default(),
+        };
+        let _ = crate::server::run(
+            &mut room,
+            ServiceSide {
+                tx: service_tx,
+                rx: service_rx,
+            },
+        )
+        .await;
+    });
+
+    to_service
+        .unbounded_send(Ok(Frame {
+            tag: 2,
+            msg: Ask(3),
+        }))
+        .unwrap();
+
+    let mut got = Vec::new();
+    while let Some(Ok(frame)) = from_service.next().await {
+        assert_eq!(frame.tag, 2, "every response shares the request's tag");
+        let done = frame.msg == Say::Done;
+        got.push(frame.msg);
+        if done {
+            break;
+        }
+    }
+    assert_eq!(
+        got,
+        vec![Say::Item(0), Say::Item(1), Say::Item(2), Say::Done],
+        "the streaming branch must serve many responses, not one error"
+    );
+}

--- a/components/jetstream_rpc/src/mux/tests.rs
+++ b/components/jetstream_rpc/src/mux/tests.rs
@@ -12,37 +12,66 @@ use futures::{channel::mpsc as fmpsc, Sink, SinkExt, Stream, StreamExt};
 use jetstream_wireformat::WireFormat;
 
 use crate::{
-    client::ClientTransport, context::Context, subscription::RDONE, Error,
-    Frame, Framer, Mux, Protocol,
+    client::ClientTransport,
+    context::Context,
+    subscription::{Rcancel, Tcancel, RCANCEL, RDONE, TCANCEL},
+    Error, Frame, Framer, Mux, Protocol,
 };
 
 const TASK: u8 = 102;
 const RITEM: u8 = 103;
 
 #[derive(Debug, PartialEq)]
-pub struct Ask(pub u32);
+pub enum Ask {
+    /// Open a subscription. `Task(0)` is the *quiet* room: it emits
+    /// nothing and stays open until something stops it, which is the
+    /// shape every long-lived subscription actually has and the one a
+    /// producer that merely counts down never exercises.
+    Task(u32),
+    /// r[impl jetstream.subscription.cancel]
+    /// Cancellation is a request on the lane, under a fresh tag, naming
+    /// its target in the payload.
+    Cancel(Tcancel),
+}
 
 #[derive(Debug, PartialEq)]
 pub enum Say {
     Item(u32),
     Done,
+    Ack(Rcancel),
 }
 
 impl Framer for Ask {
     fn message_type(&self) -> u8 {
-        TASK
+        match self {
+            Ask::Task(_) => TASK,
+            Ask::Cancel(_) => TCANCEL,
+        }
     }
 
     fn byte_size(&self) -> u32 {
-        4
+        match self {
+            Ask::Task(_) => 4,
+            Ask::Cancel(c) => WireFormat::byte_size(c),
+        }
     }
 
     fn encode<W: io::Write>(&self, w: &mut W) -> io::Result<()> {
-        WireFormat::encode(&self.0, w)
+        match self {
+            Ask::Task(n) => WireFormat::encode(n, w),
+            Ask::Cancel(c) => WireFormat::encode(c, w),
+        }
     }
 
-    fn decode<R: io::Read>(r: &mut R, _ty: u8) -> io::Result<Self> {
-        Ok(Ask(WireFormat::decode(r)?))
+    fn decode<R: io::Read>(r: &mut R, ty: u8) -> io::Result<Self> {
+        match ty {
+            TASK => Ok(Ask::Task(WireFormat::decode(r)?)),
+            TCANCEL => Ok(Ask::Cancel(WireFormat::decode(r)?)),
+            other => Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("unknown message type: {other}"),
+            )),
+        }
     }
 }
 
@@ -54,6 +83,7 @@ impl Framer for Say {
         match self {
             Say::Item(_) => RITEM,
             Say::Done => RDONE,
+            Say::Ack(_) => RCANCEL,
         }
     }
 
@@ -61,6 +91,7 @@ impl Framer for Say {
         match self {
             Say::Item(_) => 4,
             Say::Done => 0,
+            Say::Ack(a) => WireFormat::byte_size(a),
         }
     }
 
@@ -68,6 +99,7 @@ impl Framer for Say {
         match self {
             Say::Item(n) => WireFormat::encode(n, w),
             Say::Done => Ok(()),
+            Say::Ack(a) => WireFormat::encode(a, w),
         }
     }
 
@@ -75,6 +107,7 @@ impl Framer for Say {
         match ty {
             RITEM => Ok(Say::Item(WireFormat::decode(r)?)),
             RDONE => Ok(Say::Done),
+            RCANCEL => Ok(Say::Ack(WireFormat::decode(r)?)),
             other => Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 format!("unknown message type: {other}"),
@@ -94,7 +127,7 @@ impl Protocol for Counting {
 }
 
 struct Duplex {
-    tx: fmpsc::UnboundedSender<Frame<Ask>>,
+    tx: fmpsc::UnboundedSender<Result<Frame<Ask>, Error>>,
     rx: fmpsc::UnboundedReceiver<Result<Frame<Say>, Error>>,
 }
 
@@ -115,7 +148,7 @@ impl Sink<Frame<Ask>> for Duplex {
         item: Frame<Ask>,
     ) -> Result<(), Error> {
         Pin::new(&mut self.tx)
-            .start_send(item)
+            .start_send(Ok(item))
             .map_err(|e| Error::new(e.to_string()))
     }
 
@@ -159,15 +192,12 @@ fn counting_transport() -> (Box<dyn ClientTransport<Counting>>, Peer) {
     let (to_client, from_server) = fmpsc::unbounded();
     let peer = to_client.clone();
     tokio::spawn(async move {
-        while let Some(Frame { tag, msg: Ask(n) }) = from_client.next().await {
+        while let Some(Ok(Frame {
+            tag,
+            msg: Ask::Task(n),
+        })) = from_client.next().await
+        {
             let mut out = to_client.clone();
-            // `Ask(0)` is a subscription that stays open: no items and no
-            // terminator, which is the shape every use case actually has
-            // and the only one in which a lane failure has anything to
-            // resolve.
-            if n == 0 {
-                continue;
-            }
             for i in 0..n {
                 let item = Frame {
                     tag,
@@ -200,7 +230,7 @@ fn counting_transport() -> (Box<dyn ClientTransport<Counting>>, Peer) {
 async fn a_streaming_call_yields_many_responses_under_one_tag() {
     let (transport, _peer) = counting_transport();
     let mux = Mux::<Counting>::new(4, transport);
-    let mut items = mux.rpc_stream(Context::default(), Ask(5), 16).await;
+    let mut items = mux.rpc_stream(Context::default(), Ask::Task(5), 16).await;
     let tag = items.tag;
 
     let mut got = Vec::new();
@@ -212,23 +242,38 @@ async fn a_streaming_call_yields_many_responses_under_one_tag() {
         assert_eq!(frame.tag, tag);
         match frame.msg {
             Say::Item(n) => got.push(n),
-            Say::Done => break,
+            Say::Done | Say::Ack(_) => break,
         }
     }
     assert_eq!(got, vec![0, 1, 2, 3, 4]);
 }
+
+/// r[impl jetstream.subscription.compat.existing-clients]
+/// Unary calls are untouched, and their tag is freed by the one response.
+#[tokio::test]
+async fn unary_calls_are_unaffected() {
+    let (transport, _peer) = counting_transport();
+    let mux = Mux::<Counting>::new(4, transport);
+    let frame = mux
+        .rpc(Context::default(), Ask::Task(1))
+        .await
+        .await
+        .unwrap();
+    assert_eq!(frame.msg, Say::Item(0));
+}
+
 /// r[impl jetstream.rcp.multiplexing]
 /// r[impl jetstream.subscription.surface.termination]
 /// A frame for a tag nobody holds is a **lane protocol error**, and
 /// every waiter on that lane is told.
 ///
-/// Three behaviours in three revisions, and the middle one was the worst.
-/// It began as `in_flight.remove(&tag).unwrap()`, so any unsolicited or
-/// duplicate frame panicked the demultiplexer and took the client with
-/// it. That became log-and-continue, which stops the panic and leaves
-/// the real problem: the stray frame proves this end and the peer
-/// disagree about what is in flight, and carrying on leaves the tag
-/// eligible for reuse — so the *next* stray frame bearing it is
+/// Three behaviours in three revisions, and the middle one was the
+/// worst. It began as `in_flight.remove(&tag).unwrap()`, so any
+/// unsolicited or duplicate frame panicked the demultiplexer and took
+/// the client with it. That became log-and-continue, which stops the
+/// panic and leaves the real problem: the stray frame proves this end
+/// and the peer disagree about what is in flight, and carrying on leaves
+/// the tag eligible for reuse — so the *next* stray frame bearing it is
 /// delivered to whichever call has since been bound to it. A detected
 /// desynchronisation becomes a silent response misbinding.
 ///
@@ -241,9 +286,9 @@ async fn an_unknown_tag_fails_the_lane_and_wakes_its_waiters() {
     let (transport, peer) = counting_transport();
     let mux = Mux::<Counting>::new(4, transport);
 
-    // A subscription that stays open, which is the case that has
-    // anything to lose: one that has already ended has been resolved.
-    let mut items = mux.rpc_stream(Context::default(), Ask(0), 8).await;
+    // The quiet room: open, and with everything still to lose. A
+    // subscription that has already ended has been resolved already.
+    let mut items = mux.rpc_stream(Context::default(), Ask::Task(0), 8).await;
 
     // Nobody ever issued tag 9.
     peer.unbounded_send(Ok(Frame {
@@ -282,22 +327,23 @@ async fn an_unknown_tag_fails_the_lane_and_wakes_its_waiters() {
 /// The demultiplexer is the lane's only reader. Awaiting a subscriber's
 /// bounded channel there means the transport's receive window is
 /// consumed by whichever subscriber stopped polling, and every other
-/// subscription and every unary call on that lane waits for it — which
-/// is the opposite of what `r[jetstream.subscription.fanout]` promises a
-/// room. The specification allows exactly two responses to a subscriber
-/// that cannot keep up, and stalling its neighbours is neither.
+/// subscription and every unary call on that lane waits for it — the
+/// opposite of what `r[jetstream.subscription.fanout]` promises a room.
+/// The specification allows exactly two responses to a subscriber that
+/// cannot keep up, and stalling its neighbours is neither.
 #[tokio::test]
 async fn a_subscriber_that_stops_reading_does_not_stall_the_lane() {
     let (transport, _peer) = counting_transport();
     let mux = Mux::<Counting>::new(4, transport);
 
     // Capacity one, and nothing ever reads it. The peer sends far more.
-    let lagging = mux.rpc_stream(Context::default(), Ask(64), 1).await;
+    let lagging = mux.rpc_stream(Context::default(), Ask::Task(64), 1).await;
 
-    // The lane must still serve somebody else, promptly. Before this
-    // fix the demultiplexer was parked awaiting the channel above and
-    // this timed out.
-    let mut healthy = mux.rpc_stream(Context::default(), Ask(2), 8).await;
+    // The lane must still serve somebody else, promptly. Before this fix
+    // the demultiplexer was parked awaiting the channel above and this
+    // timed out.
+    let mut healthy =
+        mux.rpc_stream(Context::default(), Ask::Task(2), 8).await;
     let first =
         tokio::time::timeout(std::time::Duration::from_secs(5), healthy.next())
             .await
@@ -350,12 +396,35 @@ impl Protocol for Room {
 
     const NAME: &'static str = "room";
     const VERSION: &'static str = "rs.jetstream.proto/room/0.0.0-test";
+
+    // r[impl jetstream.subscription.cancel]
+    fn tcancel(oldtag: u16, binding: u64) -> Option<Ask> {
+        Some(Ask::Cancel(Tcancel { oldtag, binding }))
+    }
 }
 
 impl crate::server::Server for Room {
     // r[impl jetstream.subscription.surface.declared]
     fn is_streaming(message_type: u8) -> bool {
         message_type == TASK
+    }
+
+    // r[impl jetstream.subscription.cancel]
+    fn cancel_target(frame: &Frame<Ask>) -> Option<u16> {
+        match &frame.msg {
+            Ask::Cancel(c) => Some(c.oldtag),
+            _ => None,
+        }
+    }
+
+    // r[impl jetstream.subscription.cancel]
+    fn cancel_ack(oldtag: u16) -> Option<Say> {
+        Some(Say::Ack(Rcancel { oldtag }))
+    }
+
+    // r[impl jetstream.subscription.termination]
+    fn cancelled_terminator() -> Option<Say> {
+        Some(Say::Done)
     }
 
     async fn rpc(
@@ -372,7 +441,11 @@ impl crate::server::Server for Room {
         frame: Frame<Ask>,
         cancel: tokio_util::sync::CancellationToken,
     ) -> crate::server::ResponseStream<Self> {
-        let Frame { tag, msg: Ask(n) } = frame;
+        let tag = frame.tag;
+        let n = match frame.msg {
+            Ask::Task(n) => n,
+            Ask::Cancel(_) => 0,
+        };
         let stopped = self.stopped.clone();
         // Note the asymmetry with the trait's *default* body, which must
         // be a bare `async move { .. }` block: `#[trait_variant::make]`
@@ -396,6 +469,14 @@ fn async_stream_items(
             // The producer watches for cancellation between items, which
             // is the whole point of it being a parameter.
             if cancel.is_cancelled() {
+                stopped.store(true, std::sync::atomic::Ordering::SeqCst);
+                return None;
+            }
+            if n == 0 {
+                // The quiet room. It has nothing to say until something
+                // stops it, which is the shape a chat room, a build log
+                // between lines, or a presence feed actually has.
+                cancel.cancelled().await;
                 stopped.store(true, std::sync::atomic::Ordering::SeqCst);
                 return None;
             }
@@ -437,7 +518,7 @@ async fn a_service_serves_a_subscription() {
             Context::default(),
             Frame {
                 tag: 3,
-                msg: Ask(4),
+                msg: Ask::Task(4),
             },
             cancel,
         )
@@ -475,7 +556,7 @@ async fn cancellation_reaches_the_producer() {
             Context::default(),
             Frame {
                 tag: 1,
-                msg: Ask(1_000_000),
+                msg: Ask::Task(1_000_000),
             },
             cancel.clone(),
         )
@@ -511,7 +592,10 @@ impl crate::server::Server for Counting {
     ) -> Result<Frame<Say>, Error> {
         Ok(Frame {
             tag: frame.tag,
-            msg: Say::Item(frame.msg.0),
+            msg: Say::Item(match frame.msg {
+                Ask::Task(n) => n,
+                Ask::Cancel(_) => 0,
+            }),
         })
     }
 }
@@ -593,7 +677,7 @@ async fn the_dispatcher_routes_a_streaming_request() {
     to_service
         .unbounded_send(Ok(Frame {
             tag: 2,
-            msg: Ask(3),
+            msg: Ask::Task(3),
         }))
         .unwrap();
 
@@ -610,5 +694,236 @@ async fn the_dispatcher_routes_a_streaming_request() {
         got,
         vec![Say::Item(0), Say::Item(1), Say::Item(2), Say::Done],
         "the streaming branch must serve many responses, not one error"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Both halves against each other, which is where the dispatcher's own
+// shape starts to matter.
+
+/// A client whose service is `server::run` driving a `Room`, over an
+/// in-memory duplex. The flag is the room's: set when the producer
+/// observed cancellation.
+fn wired() -> (Mux<Room>, std::sync::Arc<std::sync::atomic::AtomicBool>) {
+    wired_with(16)
+}
+
+fn wired_with(
+    tags: u16,
+) -> (Mux<Room>, std::sync::Arc<std::sync::atomic::AtomicBool>) {
+    let (to_service, service_rx) = fmpsc::unbounded();
+    let (service_tx, from_service) = fmpsc::unbounded();
+    let stopped: std::sync::Arc<std::sync::atomic::AtomicBool> =
+        Default::default();
+    let theirs = stopped.clone();
+    tokio::spawn(async move {
+        let mut room = Room { stopped: theirs };
+        let _ = crate::server::run(
+            &mut room,
+            ServiceSide {
+                tx: service_tx,
+                rx: service_rx,
+            },
+        )
+        .await;
+    });
+    let transport = Duplex {
+        tx: to_service,
+        rx: from_service,
+    };
+    (Mux::<Room>::new(tags, Box::new(transport)), stopped)
+}
+
+/// Collect a subscription's items up to its terminator, with a deadline
+/// so a dispatcher that stopped serving fails the test instead of hanging
+/// it.
+async fn drain(items: &mut crate::RpcStream<Room>, what: &str) -> Vec<u32> {
+    let mut got = Vec::new();
+    loop {
+        let next = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            items.next(),
+        )
+        .await
+        .unwrap_or_else(|_| panic!("{what}"));
+        match next {
+            Some(Ok(Frame {
+                msg: Say::Item(n), ..
+            })) => got.push(n),
+            _ => return got,
+        }
+    }
+}
+
+/// r[impl jetstream.subscription.definition]
+/// A subscription is one call among the lane's others, not a takeover of
+/// it. `r[jetstream.subscription.realisation.opaque]` lets an
+/// implementation put many subscriptions on one lane — which it can only
+/// do if a lane serving one is still reading the next request.
+///
+/// This is the break: the dispatcher used to serve a subscription by
+/// looping on its items, which never polls the transport again. A room
+/// that stays open — the normal case — took the lane with it.
+#[tokio::test]
+async fn a_subscription_does_not_block_the_lane() {
+    let (mux, _stopped) = wired();
+
+    // A room that will not finish on its own.
+    let _quiet = mux.rpc_stream(Context::default(), Ask::Task(0), 8).await;
+
+    let mut second = mux.rpc_stream(Context::default(), Ask::Task(3), 8).await;
+    let got = drain(
+        &mut second,
+        "an open subscription must not stop the lane serving the next request",
+    )
+    .await;
+    assert_eq!(got, vec![0, 1, 2]);
+}
+
+/// r[impl jetstream.subscription.cancel]
+/// Cancellation arrives as a request on the lane, under a fresh tag,
+/// naming its target. It must reach the producer, terminate the
+/// subscription, and be acknowledged.
+#[tokio::test]
+async fn a_cancellation_frame_stops_the_producer() {
+    let (mux, stopped) = wired();
+    let mut quiet = mux.rpc_stream(Context::default(), Ask::Task(0), 8).await;
+    let tag = quiet.tag;
+
+    let ack = tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        mux.rpc(
+            Context::default(),
+            Ask::Cancel(Tcancel {
+                oldtag: tag,
+                binding: 0,
+            }),
+        )
+        .await,
+    )
+    .await
+    .expect("a cancellation must be answered")
+    .unwrap();
+    assert_eq!(ack.msg, Say::Ack(Rcancel { oldtag: tag }));
+
+    assert!(
+        stopped.load(std::sync::atomic::Ordering::SeqCst),
+        "cancellation must reach the work, not merely the delivery"
+    );
+
+    // r[impl jetstream.subscription.termination]
+    // The subscription still ends with a terminator: without one the
+    // caller's tag is held for the life of the lane.
+    let last =
+        tokio::time::timeout(std::time::Duration::from_secs(5), quiet.next())
+            .await
+            .expect("a cancelled subscription must terminate");
+    assert_eq!(last.unwrap().unwrap().msg, Say::Done);
+}
+
+/// r[impl jetstream.subscription.surface.cancellation]
+/// Dropping the stream is how a Rust caller cancels, so dropping it must
+/// do everything cancelling does — including telling the producer.
+#[tokio::test]
+async fn dropping_the_subscription_stops_the_producer() {
+    let (mux, stopped) = wired();
+    let quiet = mux.rpc_stream(Context::default(), Ask::Task(0), 8).await;
+    drop(quiet);
+
+    let deadline =
+        std::time::Instant::now() + std::time::Duration::from_secs(5);
+    while !stopped.load(std::sync::atomic::Ordering::SeqCst) {
+        assert!(
+            std::time::Instant::now() < deadline,
+            "dropping the subscription must stop the producer"
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+}
+
+/// r[impl jetstream.subscription.identity]
+/// A cancelled subscription's tag comes free again, and only then. The
+/// pool here is small enough that a single leaked tag stops the fourth
+/// round — which is what a subscription ending with no terminator would
+/// have done, since `r[jetstream.subscription.identity]` forbids
+/// releasing the tag at drop.
+#[tokio::test]
+async fn a_cancelled_subscription_frees_its_tag() {
+    let (mux, _stopped) = wired_with(2);
+    for round in 0..8 {
+        let mut quiet =
+            mux.rpc_stream(Context::default(), Ask::Task(0), 8).await;
+        let tag = quiet.tag;
+        let ack = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            mux.rpc(
+                Context::default(),
+                Ask::Cancel(Tcancel {
+                    oldtag: tag,
+                    binding: 0,
+                }),
+            )
+            .await,
+        )
+        .await
+        .unwrap_or_else(|_| panic!("round {round} ran out of tags"))
+        .unwrap();
+        assert_eq!(ack.msg, Say::Ack(Rcancel { oldtag: tag }));
+        // Drain to the terminator, which is what releases the tag.
+        let mut got = drain(&mut quiet, "the terminator must arrive").await;
+        got.clear();
+    }
+}
+
+/// A subscription that ended has nothing to cancel. Dropping it must not
+/// put a cancellation on the wire: the tag is already free, and a service
+/// would have to answer a cancellation for a subscription it has
+/// forgotten. The test plays the service itself, so it sees exactly which
+/// requests arrive.
+#[tokio::test]
+async fn a_finished_subscription_sends_no_cancellation() {
+    let (to_server, mut from_client) = fmpsc::unbounded();
+    let (to_client, from_server) = fmpsc::unbounded();
+    let mux = Mux::<Room>::new(
+        4,
+        Box::new(Duplex {
+            tx: to_server,
+            rx: from_server,
+        }),
+    );
+
+    let mut items = mux.rpc_stream(Context::default(), Ask::Task(1), 8).await;
+    let Some(Ok(Frame {
+        tag,
+        msg: Ask::Task(1),
+    })) = from_client.next().await
+    else {
+        panic!("the subscription request must arrive first");
+    };
+    to_client
+        .unbounded_send(Ok(Frame {
+            tag,
+            msg: Say::Item(0),
+        }))
+        .unwrap();
+    to_client
+        .unbounded_send(Ok(Frame {
+            tag,
+            msg: Say::Done,
+        }))
+        .unwrap();
+
+    let got = drain(&mut items, "the subscription must complete").await;
+    assert_eq!(got, vec![0]);
+    drop(items);
+
+    assert!(
+        tokio::time::timeout(
+            std::time::Duration::from_millis(200),
+            from_client.next(),
+        )
+        .await
+        .is_err(),
+        "a subscription that already ended needs no cancelling"
     );
 }

--- a/components/jetstream_rpc/src/mux/tests.rs
+++ b/components/jetstream_rpc/src/mux/tests.rs
@@ -423,7 +423,8 @@ impl crate::server::Server for Room {
     }
 
     // r[impl jetstream.subscription.termination]
-    fn cancelled_terminator() -> Option<Say> {
+    fn cancelled_terminator(method: u8) -> Option<Say> {
+        assert_eq!(method, TASK, "the terminator must know its method");
         Some(Say::Done)
     }
 

--- a/components/jetstream_rpc/src/server.rs
+++ b/components/jetstream_rpc/src/server.rs
@@ -1,14 +1,15 @@
 use std::{pin::pin, str::FromStr};
 
-use crate::{
-    context::{Context, Contextual},
-    Error, Frame, Protocol, Version,
-};
 use futures::{Sink, Stream};
 use jetstream_wireformat::WireFormat;
 use tokio_util::{
     bytes::{self, Buf, BufMut},
     codec::{Decoder, Encoder},
+};
+
+use crate::{
+    context::{Context, Contextual},
+    Error, Frame, Framer, Protocol, Version,
 };
 
 pub struct ServerCodec<P: Protocol> {
@@ -146,17 +147,98 @@ pub trait Server: Protocol + Send + Sync {
         context: Context,
         frame: Frame<Self::Request>,
     ) -> Result<Frame<Self::Response>, Self::Error>;
+
+    /// r[impl jetstream.subscription.surface.declared]
+    /// Whether a request of this message type opens a subscription. The
+    /// declaration is the protocol's, not the call site's, so the
+    /// dispatcher can route before it moves the frame.
+    ///
+    /// Defaults to "no streaming methods", which is every protocol
+    /// written before this existed.
+    fn is_streaming(_message_type: u8) -> bool {
+        false
+    }
+
+    /// r[impl jetstream.subscription.overview]
+    /// Serve a subscription: one request, many responses.
+    ///
+    /// r[impl jetstream.subscription.cancel]
+    /// `cancel` is how the producer learns the subscriber has gone.
+    /// Releasing only the delivery obligation is not enough — an
+    /// inference or a build must be able to stop, not merely stop being
+    /// listened to — so this is a parameter rather than something the
+    /// dispatcher keeps to itself.
+    ///
+    /// Failures travel as items, per `r[jetstream.subscription.termination]`,
+    /// which is also why the end can carry a value.
+    ///
+    /// r[impl jetstream.subscription.compat.rpc-layer]
+    /// Defaulted, so every existing `Server` implementation compiles
+    /// untouched: the breakage this change carries is on the client,
+    /// where `RpcCall` resolves to one frame.
+    async fn rpc_stream(
+        &mut self,
+        context: Context,
+        frame: Frame<Self::Request>,
+        cancel: tokio_util::sync::CancellationToken,
+    ) -> ResponseStream<Self>
+    where
+        // The served stream is boxed and owned, so what it carries must
+        // outlive the call that made it. Every real protocol's messages
+        // are owned values, so this costs nothing but has to be said —
+        // the same bound `Datagrams` needs, for the same reason.
+        Self::Response: 'static,
+        Self::Error: 'static,
+    {
+        let _ = (context, frame, cancel);
+        // A bare async block, not a normal body: `#[trait_variant::make]`
+        // rewrites `async fn` into `fn -> impl Future`, so the body must
+        // *be* the future. The two natural spellings fail with errors
+        // that point elsewhere entirely. An *implementation* of this
+        // method writes an ordinary body, since the macro rewrites the
+        // trait and not its impls.
+        async move { Box::pin(futures::stream::empty()) as ResponseStream<Self> }
+    }
 }
+
+/// The items a served subscription yields.
+pub type ResponseStream<P> = std::pin::Pin<
+    Box<
+        dyn futures::Stream<
+                Item = Result<
+                    Frame<<P as Protocol>::Response>,
+                    <P as Protocol>::Error,
+                >,
+            > + Send,
+    >,
+>;
 
 pub async fn run<T, P>(p: &mut P, mut stream: T) -> Result<(), P::Error>
 where
     T: ServiceTransport<P>,
     P: Server,
+    P::Response: 'static,
+    P::Error: 'static,
 {
     use futures::{SinkExt, StreamExt};
     let mut a = pin!(p);
     while let Some(Ok(frame)) = stream.next().await {
-        stream.send(a.rpc(stream.context(), frame).await?).await?
+        let context = stream.context();
+        // r[impl jetstream.subscription.surface.declared]
+        // Routed on the declared message type, before the frame moves.
+        if P::is_streaming(frame.msg.message_type()) {
+            // r[impl jetstream.subscription.cancel]
+            // The token the producer watches, cancelled when the served
+            // stream ends under it.
+            let cancel = tokio_util::sync::CancellationToken::new();
+            let mut items = a.rpc_stream(context, frame, cancel.clone()).await;
+            while let Some(item) = items.next().await {
+                stream.send(item?).await?;
+            }
+            cancel.cancel();
+        } else {
+            stream.send(a.rpc(context, frame).await?).await?
+        }
     }
     Ok(())
 }

--- a/components/jetstream_rpc/src/server.rs
+++ b/components/jetstream_rpc/src/server.rs
@@ -189,7 +189,13 @@ pub trait Server: Protocol + Send + Sync {
     /// `r[jetstream.subscription.identity]` for why it cannot simply be
     /// released. The dispatcher supplies one, and the protocol says what
     /// value it has.
-    fn cancelled_terminator() -> Option<Self::Response> {
+    ///
+    /// r[impl jetstream.subscription.termination.discriminant]
+    /// `method` is the message type of the request that opened the
+    /// subscription. A protocol with one streaming method can ignore it;
+    /// one with two cannot, because the terminator's payload names its
+    /// method and only the request says which method this was.
+    fn cancelled_terminator(_method: u8) -> Option<Self::Response> {
         None
     }
 
@@ -292,6 +298,10 @@ impl<P: Protocol> Stream for Served<P> {
 /// What the dispatcher remembers about a subscription it is serving.
 struct Open {
     cancel: tokio_util::sync::CancellationToken,
+    /// The message type of the request that opened it. The terminator
+    /// the dispatcher may have to supply names its method, and only the
+    /// request knows which method that was.
+    method: u8,
     /// Set when the producer emitted a terminator of its own, so the
     /// dispatcher does not send a second one.
     terminated: bool,
@@ -349,7 +359,7 @@ where
                     if let Some(o) = open.remove(&tag) {
                         // r[impl jetstream.subscription.dispatch.terminator]
                         if !o.terminated {
-                            if let Some(msg) = P::cancelled_terminator() {
+                            if let Some(msg) = P::cancelled_terminator(o.method) {
                                 sink.send(Frame { tag, msg }).await?;
                             }
                         }
@@ -394,6 +404,7 @@ where
                 // moves.
                 if P::is_streaming(frame.msg.message_type()) {
                     let tag = frame.tag;
+                    let method = frame.msg.message_type();
                     // r[impl jetstream.subscription.cancel]
                     // The token the producer watches.
                     let cancel = tokio_util::sync::CancellationToken::new();
@@ -402,7 +413,12 @@ where
                             .await;
                     open.insert(
                         tag,
-                        Open { cancel, terminated: false, ack_to: None },
+                        Open {
+                            cancel,
+                            method,
+                            terminated: false,
+                            ack_to: None,
+                        },
                     );
                     active.push(Served { tag, inner: Some(inner) });
                 } else {

--- a/components/jetstream_rpc/src/server.rs
+++ b/components/jetstream_rpc/src/server.rs
@@ -159,6 +159,40 @@ pub trait Server: Protocol + Send + Sync {
         false
     }
 
+    /// r[impl jetstream.subscription.dispatch.declared]
+    /// r[impl jetstream.subscription.cancel]
+    /// Whether this request is a cancellation, and which subscription it
+    /// names. Cancellation travels as an ordinary request under a fresh
+    /// tag, so the dispatcher has to be told how to recognise one — the
+    /// message id is global, but decoding the payload is the protocol's.
+    ///
+    /// Defaulted to "this protocol has no cancellation", which is
+    /// correct for every protocol without subscriptions.
+    fn cancel_target(_frame: &Frame<Self::Request>) -> Option<u16> {
+        None
+    }
+
+    /// r[impl jetstream.subscription.dispatch.declared]
+    /// r[impl jetstream.subscription.cancel]
+    /// The acknowledgement for a cancelled subscription, sent under the
+    /// *cancellation's* tag once the subscription has stopped emitting.
+    fn cancel_ack(_oldtag: u16) -> Option<Self::Response> {
+        None
+    }
+
+    /// r[impl jetstream.subscription.dispatch.terminator]
+    /// r[impl jetstream.subscription.termination]
+    /// The terminator for a subscription that was cut short. A producer
+    /// stopped by cancellation returns from its stream without saying
+    /// anything, and a subscription that ends with no terminator leaves
+    /// the caller's tag in flight for the life of the lane — see
+    /// `r[jetstream.subscription.identity]` for why it cannot simply be
+    /// released. The dispatcher supplies one, and the protocol says what
+    /// value it has.
+    fn cancelled_terminator() -> Option<Self::Response> {
+        None
+    }
+
     /// r[impl jetstream.subscription.overview]
     /// Serve a subscription: one request, many responses.
     ///
@@ -213,7 +247,60 @@ pub type ResponseStream<P> = std::pin::Pin<
     >,
 >;
 
-pub async fn run<T, P>(p: &mut P, mut stream: T) -> Result<(), P::Error>
+/// One served subscription, tagged, and — unlike the stream it wraps —
+/// able to say that it *ended*.
+///
+/// r[impl jetstream.subscription.surface.composition]
+/// The same erasure the surface rule is about bites the dispatcher:
+/// `SelectAll` drops a finished stream silently, so a subscription that
+/// stopped would leave its tag open and its cancellation unacknowledged.
+/// The end is a value here for exactly the reason it is one for callers.
+struct Served<P: Protocol> {
+    tag: u16,
+    inner: Option<ResponseStream<P>>,
+}
+
+enum Out<P: Protocol> {
+    Item(u16, Result<Frame<P::Response>, P::Error>),
+    Ended(u16),
+}
+
+impl<P: Protocol> Stream for Served<P> {
+    type Item = Out<P>;
+
+    fn poll_next(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        use std::task::Poll;
+        let this = self.get_mut();
+        let tag = this.tag;
+        let Some(inner) = this.inner.as_mut() else {
+            return Poll::Ready(None);
+        };
+        match inner.as_mut().poll_next(cx) {
+            Poll::Ready(Some(item)) => Poll::Ready(Some(Out::Item(tag, item))),
+            Poll::Ready(None) => {
+                this.inner = None;
+                Poll::Ready(Some(Out::Ended(tag)))
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+/// What the dispatcher remembers about a subscription it is serving.
+struct Open {
+    cancel: tokio_util::sync::CancellationToken,
+    /// Set when the producer emitted a terminator of its own, so the
+    /// dispatcher does not send a second one.
+    terminated: bool,
+    /// The tag of the cancellation waiting to be acknowledged, if one
+    /// arrived. The acknowledgement is owed *after* the last item.
+    ack_to: Option<u16>,
+}
+
+pub async fn run<T, P>(p: &mut P, transport: T) -> Result<(), P::Error>
 where
     T: ServiceTransport<P>,
     P: Server,
@@ -221,24 +308,116 @@ where
     P::Error: 'static,
 {
     use futures::{SinkExt, StreamExt};
+
+    // The context is the transport's, not the frame's: it describes the
+    // peer at the other end of this lane, which does not change between
+    // requests. Reading it once is what lets the transport be split.
+    let context = transport.context();
+
+    // r[impl jetstream.subscription.dispatch.concurrent]
+    // r[impl jetstream.subscription.definition]
+    // Split, because a subscription is one call among the lane's others.
+    // Serving one by looping on its items never polls the transport
+    // again, so an open subscription — the normal case, a room that
+    // stays open — took the lane with it: no second request served, and
+    // no cancellation could arrive, which made the cancellation rule
+    // unimplementable rather than merely unimplemented.
+    let (mut sink, mut source) = transport.split();
+    let mut active: futures::stream::SelectAll<Served<P>> =
+        futures::stream::SelectAll::new();
+    let mut open: std::collections::BTreeMap<u16, Open> =
+        std::collections::BTreeMap::new();
     let mut a = pin!(p);
-    while let Some(Ok(frame)) = stream.next().await {
-        let context = stream.context();
-        // r[impl jetstream.subscription.surface.declared]
-        // Routed on the declared message type, before the frame moves.
-        if P::is_streaming(frame.msg.message_type()) {
-            // r[impl jetstream.subscription.cancel]
-            // The token the producer watches, cancelled when the served
-            // stream ends under it.
-            let cancel = tokio_util::sync::CancellationToken::new();
-            let mut items = a.rpc_stream(context, frame, cancel.clone()).await;
-            while let Some(item) = items.next().await {
-                stream.send(item?).await?;
+
+    loop {
+        tokio::select! {
+            // Items first: a producer that is ready should not wait
+            // behind an inbound request.
+            biased;
+
+            Some(out) = active.next(), if !active.is_empty() => match out {
+                Out::Item(tag, item) => {
+                    let frame = item?;
+                    if frame.msg.message_type() == crate::subscription::RDONE {
+                        if let Some(o) = open.get_mut(&tag) {
+                            o.terminated = true;
+                        }
+                    }
+                    sink.send(frame).await?;
+                }
+                Out::Ended(tag) => {
+                    if let Some(o) = open.remove(&tag) {
+                        // r[impl jetstream.subscription.dispatch.terminator]
+                        if !o.terminated {
+                            if let Some(msg) = P::cancelled_terminator() {
+                                sink.send(Frame { tag, msg }).await?;
+                            }
+                        }
+                        // r[impl jetstream.subscription.cancel]
+                        // After every item already emitted, which is what
+                        // makes the tag safe to reuse.
+                        if let Some(ack_tag) = o.ack_to {
+                            if let Some(msg) = P::cancel_ack(tag) {
+                                sink.send(Frame { tag: ack_tag, msg }).await?;
+                            }
+                        }
+                    }
+                }
+            },
+
+            inbound = source.next() => {
+                let Some(Ok(frame)) = inbound else { break };
+
+                // r[impl jetstream.subscription.cancel]
+                if let Some(oldtag) = P::cancel_target(&frame) {
+                    match open.get_mut(&oldtag) {
+                        Some(o) => {
+                            o.ack_to = Some(frame.tag);
+                            o.cancel.cancel();
+                        }
+                        // Nothing by that tag: already finished, or never
+                        // existed. Acknowledge anyway — a cancellation
+                        // racing a terminator is normal, and the caller
+                        // is owed an answer either way.
+                        None => {
+                            if let Some(msg) = P::cancel_ack(oldtag) {
+                                sink.send(Frame { tag: frame.tag, msg })
+                                    .await?;
+                            }
+                        }
+                    }
+                    continue;
+                }
+
+                // r[impl jetstream.subscription.surface.declared]
+                // Routed on the declared message type, before the frame
+                // moves.
+                if P::is_streaming(frame.msg.message_type()) {
+                    let tag = frame.tag;
+                    // r[impl jetstream.subscription.cancel]
+                    // The token the producer watches.
+                    let cancel = tokio_util::sync::CancellationToken::new();
+                    let inner =
+                        a.rpc_stream(context.clone(), frame, cancel.clone())
+                            .await;
+                    open.insert(
+                        tag,
+                        Open { cancel, terminated: false, ack_to: None },
+                    );
+                    active.push(Served { tag, inner: Some(inner) });
+                } else {
+                    sink.send(a.rpc(context.clone(), frame).await?).await?
+                }
             }
-            cancel.cancel();
-        } else {
-            stream.send(a.rpc(context, frame).await?).await?
         }
+    }
+
+    // r[impl jetstream.subscription.cancel]
+    // The lane is gone, so every producer on it has lost its subscriber.
+    // Leaving the tokens uncancelled would leave the work running with
+    // nowhere to deliver — the very thing cancellation exists to stop.
+    for (_, o) in open {
+        o.cancel.cancel();
     }
     Ok(())
 }

--- a/components/jetstream_rpc/src/server.rs
+++ b/components/jetstream_rpc/src/server.rs
@@ -339,28 +339,45 @@ where
         std::collections::BTreeMap::new();
     let mut a = pin!(p);
 
-    loop {
+    // The reason the loop stopped, so the cleanup below runs on every
+    // exit rather than only the tidy one.
+    let outcome: Result<(), P::Error> = loop {
+        // r[impl jetstream.subscription.dispatch.concurrent]
+        // Fair selection, deliberately. This was `biased` with items
+        // first, on the reasoning that a ready producer should not wait
+        // behind an inbound request — which is exactly backwards. An
+        // always-ready producer, and `repeat` is enough, makes the item
+        // branch ready on every iteration, so the inbound branch is never
+        // selected and the chatty subscription prevents *its own*
+        // cancellation from ever being read. That is the failure this
+        // whole dispatcher exists to remove, reintroduced by an
+        // optimisation.
         tokio::select! {
-            // Items first: a producer that is ready should not wait
-            // behind an inbound request.
-            biased;
-
             Some(out) = active.next(), if !active.is_empty() => match out {
                 Out::Item(tag, item) => {
-                    let frame = item?;
+                    let frame = match item {
+                        Ok(frame) => frame,
+                        Err(e) => break Err(e),
+                    };
                     if frame.msg.message_type() == crate::subscription::RDONE {
                         if let Some(o) = open.get_mut(&tag) {
                             o.terminated = true;
                         }
                     }
-                    sink.send(frame).await?;
+                    if let Err(e) = sink.send(frame).await {
+                        break Err(e);
+                    }
                 }
                 Out::Ended(tag) => {
                     if let Some(o) = open.remove(&tag) {
                         // r[impl jetstream.subscription.dispatch.terminator]
                         if !o.terminated {
                             if let Some(msg) = P::cancelled_terminator(o.method) {
-                                sink.send(Frame { tag, msg }).await?;
+                                if let Err(e) =
+                                    sink.send(Frame { tag, msg }).await
+                                {
+                                    break Err(e);
+                                }
                             }
                         }
                         // r[impl jetstream.subscription.cancel]
@@ -368,7 +385,11 @@ where
                         // makes the tag safe to reuse.
                         if let Some(ack_tag) = o.ack_to {
                             if let Some(msg) = P::cancel_ack(tag) {
-                                sink.send(Frame { tag: ack_tag, msg }).await?;
+                                if let Err(e) =
+                                    sink.send(Frame { tag: ack_tag, msg }).await
+                                {
+                                    break Err(e);
+                                }
                             }
                         }
                     }
@@ -376,7 +397,7 @@ where
             },
 
             inbound = source.next() => {
-                let Some(Ok(frame)) = inbound else { break };
+                let Some(Ok(frame)) = inbound else { break Ok(()) };
 
                 // r[impl jetstream.subscription.cancel]
                 if let Some(oldtag) = P::cancel_target(&frame) {
@@ -391,8 +412,12 @@ where
                         // is owed an answer either way.
                         None => {
                             if let Some(msg) = P::cancel_ack(oldtag) {
-                                sink.send(Frame { tag: frame.tag, msg })
-                                    .await?;
+                                if let Err(e) = sink
+                                    .send(Frame { tag: frame.tag, msg })
+                                    .await
+                                {
+                                    break Err(e);
+                                }
                             }
                         }
                     }
@@ -422,18 +447,30 @@ where
                     );
                     active.push(Served { tag, inner: Some(inner) });
                 } else {
-                    sink.send(a.rpc(context.clone(), frame).await?).await?
+                    let response = match a.rpc(context.clone(), frame).await {
+                        Ok(response) => response,
+                        Err(e) => break Err(e),
+                    };
+                    if let Err(e) = sink.send(response).await {
+                        break Err(e);
+                    }
                 }
             }
         }
-    }
+    };
 
     // r[impl jetstream.subscription.cancel]
     // The lane is gone, so every producer on it has lost its subscriber.
     // Leaving the tokens uncancelled would leave the work running with
     // nowhere to deliver — the very thing cancellation exists to stop.
+    //
+    // This runs on *every* exit. It used to sit after a body full of
+    // `?`, so any stream or sink error returned straight past it: the
+    // tokens were merely dropped, and a producer holding a clone — a
+    // detached task, which is the shape `producing` creates — never
+    // learned its lane had gone.
     for (_, o) in open {
         o.cancel.cancel();
     }
-    Ok(())
+    outcome
 }

--- a/components/jetstream_rpc/src/server.rs
+++ b/components/jetstream_rpc/src/server.rs
@@ -305,9 +305,18 @@ struct Open {
     /// Set when the producer emitted a terminator of its own, so the
     /// dispatcher does not send a second one.
     terminated: bool,
-    /// The tag of the cancellation waiting to be acknowledged, if one
-    /// arrived. The acknowledgement is owed *after* the last item.
-    ack_to: Option<u16>,
+    /// The tags of the cancellations waiting to be acknowledged. The
+    /// acknowledgement is owed *after* the last item.
+    ///
+    /// r[impl jetstream.subscription.cancel]
+    /// A list rather than one tag: nothing stops a caller — or the
+    /// client's own drop path, which queues a cancellation of its own —
+    /// from sending two before the producer notices the first. Keeping
+    /// only the latest silently drops the earlier one, and every
+    /// cancellation is owed an answer; the tag it was sent under stays
+    /// in flight until it gets one, so the ones forgotten here are
+    /// control tags leaked for the life of the lane.
+    ack_to: Vec<u16>,
 }
 
 pub async fn run<T, P>(p: &mut P, transport: T) -> Result<(), P::Error>
@@ -341,7 +350,7 @@ where
 
     // The reason the loop stopped, so the cleanup below runs on every
     // exit rather than only the tidy one.
-    let outcome: Result<(), P::Error> = loop {
+    let outcome: Result<(), P::Error> = 'dispatch: loop {
         // r[impl jetstream.subscription.dispatch.concurrent]
         // Fair selection, deliberately. This was `biased` with items
         // first, on the reasoning that a ready producer should not wait
@@ -383,12 +392,16 @@ where
                         // r[impl jetstream.subscription.cancel]
                         // After every item already emitted, which is what
                         // makes the tag safe to reuse.
-                        if let Some(ack_tag) = o.ack_to {
+                        for ack_tag in &o.ack_to {
                             if let Some(msg) = P::cancel_ack(tag) {
-                                if let Err(e) =
-                                    sink.send(Frame { tag: ack_tag, msg }).await
+                                if let Err(e) = sink
+                                    .send(Frame {
+                                        tag: *ack_tag,
+                                        msg,
+                                    })
+                                    .await
                                 {
-                                    break Err(e);
+                                    break 'dispatch Err(e);
                                 }
                             }
                         }
@@ -403,7 +416,7 @@ where
                 if let Some(oldtag) = P::cancel_target(&frame) {
                     match open.get_mut(&oldtag) {
                         Some(o) => {
-                            o.ack_to = Some(frame.tag);
+                            o.ack_to.push(frame.tag);
                             o.cancel.cancel();
                         }
                         // Nothing by that tag: already finished, or never
@@ -442,7 +455,7 @@ where
                             cancel,
                             method,
                             terminated: false,
-                            ack_to: None,
+                            ack_to: Vec::new(),
                         },
                     );
                     active.push(Served { tag, inner: Some(inner) });


### PR DESCRIPTION
Third of the stack: #694 (spec) → #695 (wire) → #696 (client) → this. Last piece before the `#[service]` macro.

## Additive on the server, as the spike predicted

`Server` gains `is_streaming` and `rpc_stream`, both defaulted. **The whole workspace builds with `--all-features` unchanged** — no existing implementation touched. That is the asymmetry `r[jetstream.subscription.compat.rpc-layer]` records after codex and I reached it independently: additive on the server, breaking on the client where `RpcCall` resolves to one frame.

## Cancellation is a parameter, not an internal detail

```rust
async fn rpc_stream(
    &mut self,
    context: Context,
    frame: Frame<Self::Request>,
    cancel: CancellationToken,
) -> ResponseStream<Self>
```

`r[jetstream.subscription.cancel]` requires cancellation to reach the **work**, and that requirement exists because writing the usage exposed a producer surface offering only a way to *send*: the loop ignoring cancellation compiles, runs, and keeps inferring after the subscriber is gone. A test holds it — a producer that ignores the token fails with `a cancelled producer stops emitting`.

Routing is on the declared message type, before the frame moves, so `is_streaming` is the protocol's answer rather than the call site's. Failures travel as items rather than as a `Result` wrapping the stream, for the same reason the end can carry a value.

## Two `trait_variant` gotchas, recorded in the code

For whoever writes the next defaulted async method on one of these traits — no existing one had a default, so this was unexplored:

- The **trait's default body** must be a bare `async move { … }` block. `#[trait_variant::make]` rewrites `async fn` into `fn -> impl Future`, so the body must *be* the future. An ordinary body gives ``Result<..> is not a future``; adding `.await` gives ``await is only allowed inside async functions``.
- An **implementation** of the same method writes an ordinary body, since the macro rewrites the trait and not its impls.

## A gap the verification found

Each test was checked by removing its fix and watching it fail. That exposed something the tests alone did not: the first four all called `rpc_stream` **directly**, so replacing the dispatcher's route with `if false` broke nothing —

```
test result: ok. 6 passed
```

The routing in `server::run` was untested. A test now drives `run` end to end, and with the route disabled reports `left: [], right: [Item(0), Item(1), Item(2), Done]`.

Also worth flagging as process rather than code: I lost this file's uncommitted work once by using `git checkout --` to undo a temporary edit. I had saved a copy of the test file before doing the same thing to it, and not this one.

58 tests in `jetstream_rpc`. Clippy clean apart from the pre-existing `jetstream_wireformat` warning; workspace builds with `--all-features`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017u7J4fStrsu5W6CoXSw11t

---
_Generated by [Claude Code](https://claude.ai/code/session_017u7J4fStrsu5W6CoXSw11t)_