### PR TITLE
feat(rpc): the typed subscription surface, and a chat room that runs on it

### DIFF
--- a/components/jetstream_rpc/src/mux/tests.rs
+++ b/components/jetstream_rpc/src/mux/tests.rs
@@ -1350,3 +1350,43 @@ async fn two_cancellations_for_one_subscription_are_both_acknowledged() {
     assert_eq!(a.unwrap().msg, Say::Ack(Rcancel { oldtag: tag }));
     assert_eq!(b.unwrap().msg, Say::Ack(Rcancel { oldtag: tag }));
 }
+
+/// r[verify jetstream.subscription.surface.termination]
+/// A decode failure is an ending. Mapping frames and leaving the stream
+/// running meant a subscriber could be told its subscription had failed
+/// and then go on hearing from it — and through `merge`, an input
+/// reported as failed keeps speaking under the same key.
+#[tokio::test]
+async fn a_decode_failure_ends_the_subscription() {
+    use crate::subscription::{Item, Subscription};
+
+    let (mux, _stopped) = wired();
+    // Five items and a terminator, so there is plenty left to leak.
+    let stream = mux.rpc_stream(Context::default(), Ask::Task(5), 16).await;
+    let mut items =
+        Subscription::<u32, ()>::from_frames(stream, |frame: Frame<Say>| {
+            match frame.msg {
+                Say::Item(0) => Ok(Item::Next(0)),
+                // Everything after the first item is rejected.
+                _ => Err(Error::new("this decoder refuses the second frame")),
+            }
+        });
+
+    assert!(
+        matches!(items.next().await, Some(Ok(Item::Next(0)))),
+        "the first item decodes",
+    );
+    assert!(
+        matches!(items.next().await, Some(Err(_))),
+        "the second is the failure",
+    );
+
+    let after =
+        tokio::time::timeout(std::time::Duration::from_secs(5), items.next())
+            .await
+            .expect("a failed subscription must end rather than hang");
+    assert!(
+        after.is_none(),
+        "nothing may follow a failure — got {after:?}",
+    );
+}

--- a/components/jetstream_rpc/src/subscription.rs
+++ b/components/jetstream_rpc/src/subscription.rs
@@ -7,7 +7,7 @@
 //! cancellation, and the endpoint identifier. The client and server
 //! plumbing that uses them lands separately.
 
-use jetstream_wireformat::{Data, JetStreamWireFormat};
+use jetstream_wireformat::{Data, JetStreamWireFormat, WireFormat};
 
 /// r[impl jetstream.subscription.compat]
 /// The terminator, and cancellation, take **global** message ids in the
@@ -120,6 +120,326 @@ impl From<&str> for Endpoint {
     fn from(name: &str) -> Self {
         Endpoint(Data(name.as_bytes().to_vec()))
     }
+}
+
+/// r[impl jetstream.subscription.termination]
+/// A terminator that carries a typed value names the method it ends.
+///
+/// `RDONE` is one **global** message id, which is what keeps
+/// `102 + 2 * index` intact for every other method — but a protocol with
+/// two subscription methods then has two terminal types sharing one id,
+/// and a decoder handed the type byte alone cannot tell which to decode.
+/// The tag would disambiguate it, and a decoder does not see the tag.
+///
+/// So the payload names its method: the message id of the *request* that
+/// opened the subscription, which is unique per method by construction.
+/// One byte, and the two rules stop contradicting each other.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Terminator<D> {
+    /// The message id of the request that opened this subscription.
+    pub method: u8,
+    pub value: D,
+}
+
+impl<D: WireFormat> WireFormat for Terminator<D> {
+    fn byte_size(&self) -> u32 {
+        1 + self.value.byte_size()
+    }
+
+    fn encode<W: std::io::Write>(&self, w: &mut W) -> std::io::Result<()> {
+        self.method.encode(w)?;
+        self.value.encode(w)
+    }
+
+    fn decode<R: std::io::Read>(r: &mut R) -> std::io::Result<Self> {
+        let method = u8::decode(r)?;
+        Ok(Terminator {
+            method,
+            value: D::decode(r)?,
+        })
+    }
+}
+
+/// r[impl jetstream.subscription.surface.terminal-value]
+/// r[impl jetstream.subscription.surface.composition]
+/// What a subscription yields. The end is a **value in the sequence**,
+/// not the absence of one.
+///
+/// Both rules need this and neither is satisfiable without it: a `Stream`
+/// ends with `None`, which has nowhere to put a result, and `select_all`
+/// drops a finished stream silently, so a merged subscription would
+/// deliver every item and no terminator.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Item<T, D> {
+    /// One item of the sequence.
+    Next(T),
+    /// The end, and what it ended with.
+    Done(D),
+}
+
+impl<T, D> Item<T, D> {
+    pub fn is_done(&self) -> bool {
+        matches!(self, Item::Done(_))
+    }
+
+    pub fn into_next(self) -> Option<T> {
+        match self {
+            Item::Next(t) => Some(t),
+            Item::Done(_) => None,
+        }
+    }
+
+    pub fn into_done(self) -> Option<D> {
+        match self {
+            Item::Next(_) => None,
+            Item::Done(d) => Some(d),
+        }
+    }
+}
+
+/// r[impl jetstream.subscription.surface]
+/// The caller's end of a subscription, in the types the caller declared.
+///
+/// A `Stream` of `Item<T, D>`, so consuming one is consuming a stream —
+/// and dropping one cancels it, because dropping the `RpcStream` inside
+/// does. Nothing in the type says whether the subscription got a lane of
+/// its own or a tag on a shared one, per
+/// `r[jetstream.subscription.realisation.opaque]`.
+pub struct Subscription<T, D> {
+    items: ItemStream<T, D>,
+}
+
+/// The boxed sequence a `Subscription` reads: items, then the end.
+pub type ItemStream<T, D> = std::pin::Pin<
+    Box<dyn futures::Stream<Item = jetstream_error::Result<Item<T, D>>> + Send>,
+>;
+
+impl<T, D> Subscription<T, D>
+where
+    T: Send + 'static,
+    D: Send + 'static,
+{
+    /// Build one from the frames of a streaming call. `decode` is the
+    /// generated protocol's: only it knows which response variant is an
+    /// item and which is the terminator.
+    pub fn from_frames<P, F>(stream: crate::RpcStream<P>, mut decode: F) -> Self
+    where
+        P: crate::Protocol + 'static,
+        P::Response: 'static,
+        F: FnMut(
+                crate::Frame<P::Response>,
+            ) -> jetstream_error::Result<Item<T, D>>
+            + Send
+            + 'static,
+    {
+        use futures::StreamExt;
+        Subscription {
+            items: Box::pin(stream.map(move |frame| decode(frame?))),
+        }
+    }
+
+    /// Build one from any stream of already-decoded items — the shape a
+    /// test, an in-process implementation, or a replay uses.
+    pub fn from_items<S>(items: S) -> Self
+    where
+        S: futures::Stream<Item = jetstream_error::Result<Item<T, D>>>
+            + Send
+            + 'static,
+    {
+        Subscription {
+            items: Box::pin(items),
+        }
+    }
+
+    /// r[impl jetstream.subscription.surface.composition]
+    /// Tag this subscription so a merge can say which one spoke. The
+    /// terminator survives the merge on its own — it is an `Item` — but
+    /// *which* subscription ended does not, and that is the other half
+    /// of what the rule requires.
+    pub fn labelled<K>(self, key: K) -> Labelled<K, T, D>
+    where
+        K: Clone,
+    {
+        Labelled { key, inner: self }
+    }
+}
+
+impl<T, D> futures::Stream for Subscription<T, D> {
+    type Item = jetstream_error::Result<Item<T, D>>;
+
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        self.items.as_mut().poll_next(cx)
+    }
+}
+
+/// A subscription that says which one it is. `Unpin`, so it goes
+/// straight into `select_all`.
+pub struct Labelled<K, T, D> {
+    key: K,
+    inner: Subscription<T, D>,
+}
+
+impl<K: Clone + Unpin, T, D> futures::Stream for Labelled<K, T, D> {
+    type Item = jetstream_error::Result<(K, Item<T, D>)>;
+
+    fn poll_next(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        use std::task::Poll;
+        let this = self.get_mut();
+        let key = this.key.clone();
+        match std::pin::Pin::new(&mut this.inner).poll_next(cx) {
+            Poll::Ready(Some(Ok(item))) => Poll::Ready(Some(Ok((key, item)))),
+            Poll::Ready(Some(Err(e))) => Poll::Ready(Some(Err(e))),
+            Poll::Ready(None) => Poll::Ready(None),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+/// r[impl jetstream.subscription.surface.composition]
+/// Merge many subscriptions without losing which one ended, or with
+/// what. Fan-in — use case 2 — and a terminal value — use case 4 — are
+/// each easy alone; this is the combination the document listed
+/// separately and never checked.
+pub fn merge<K, T, D, I>(
+    subscriptions: I,
+) -> futures::stream::SelectAll<Labelled<K, T, D>>
+where
+    K: Clone + Unpin,
+    T: Send + 'static,
+    D: Send + 'static,
+    I: IntoIterator<Item = (K, Subscription<T, D>)>,
+{
+    futures::stream::select_all(
+        subscriptions.into_iter().map(|(k, s)| s.labelled(k)),
+    )
+}
+
+/// The producer stopped because its subscriber did.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Cancelled;
+
+impl std::fmt::Display for Cancelled {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("the subscription was cancelled")
+    }
+}
+
+impl std::error::Error for Cancelled {}
+
+/// The signal a producer watches. Re-exported so a producer need not
+/// depend on `tokio-util` to write against this surface.
+pub use tokio_util::sync::CancellationToken;
+
+/// r[impl jetstream.subscription.surface.producer]
+/// The producer's end. It can send, and it can **learn** — which is the
+/// half a bare `Sender` cannot do, and the reason a producer loop written
+/// against one compiles, runs, and keeps inferring long after the
+/// subscriber has gone.
+///
+/// Cancellation is offered all three ways the rule allows: a signal to
+/// await, a flag to test, and a send that fails once cancelled. A loop
+/// that checks none of them still stops at its next `send`.
+pub struct Producer<T, D> {
+    tx: tokio::sync::mpsc::Sender<Item<T, D>>,
+    cancel: tokio_util::sync::CancellationToken,
+}
+
+impl<T, D> Producer<T, D> {
+    /// Emit one item. Fails once the subscriber has gone, so a loop that
+    /// watches nothing else still terminates.
+    pub async fn send(&self, item: T) -> Result<(), Cancelled> {
+        tokio::select! {
+            biased;
+            _ = self.cancel.cancelled() => Err(Cancelled),
+            sent = self.tx.send(Item::Next(item)) => {
+                sent.map_err(|_| Cancelled)
+            }
+        }
+    }
+
+    /// r[impl jetstream.subscription.termination]
+    /// End the subscription, carrying the result. Consuming `self` is
+    /// the point: a producer that has finished cannot emit again.
+    pub async fn finish(self, done: D) {
+        let _ = self.tx.send(Item::Done(done)).await;
+    }
+
+    pub fn is_cancelled(&self) -> bool {
+        self.cancel.is_cancelled()
+    }
+
+    /// Resolves when the subscriber goes away — the shape a producer
+    /// that is waiting on something else selects over.
+    pub async fn cancelled(&self) {
+        self.cancel.cancelled().await
+    }
+
+    /// The token itself, for a producer that hands cancellation onward
+    /// to the work rather than watching it here.
+    pub fn cancellation(&self) -> tokio_util::sync::CancellationToken {
+        self.cancel.clone()
+    }
+}
+
+/// The served side of a subscription: what the producer writes into.
+pub struct Items<T, D> {
+    rx: tokio::sync::mpsc::Receiver<Item<T, D>>,
+}
+
+impl<T, D> futures::Stream for Items<T, D> {
+    type Item = Item<T, D>;
+
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        self.rx.poll_recv(cx)
+    }
+}
+
+impl<T, D> Items<T, D>
+where
+    T: Send + 'static,
+    D: Send + 'static,
+{
+    /// Turn decoded items into the frames a dispatcher serves. `encode`
+    /// is the generated protocol's, for the same reason `decode` is.
+    pub fn into_frames<P, F>(
+        self,
+        tag: u16,
+        mut encode: F,
+    ) -> crate::server::ResponseStream<P>
+    where
+        P: crate::Protocol + 'static,
+        P::Response: 'static,
+        P::Error: 'static,
+        F: FnMut(Item<T, D>) -> P::Response + Send + 'static,
+    {
+        use futures::StreamExt;
+        Box::pin(self.map(move |item| {
+            Ok(crate::Frame {
+                tag,
+                msg: encode(item),
+            })
+        }))
+    }
+}
+
+/// r[impl jetstream.subscription.surface.producer]
+/// The producer/consumer pair for one subscription. `cancel` is the
+/// dispatcher's token, so cancelling the subscription cancels the work.
+pub fn channel<T, D>(
+    capacity: usize,
+    cancel: tokio_util::sync::CancellationToken,
+) -> (Producer<T, D>, Items<T, D>) {
+    let (tx, rx) = tokio::sync::mpsc::channel(capacity);
+    (Producer { tx, cancel }, Items { rx })
 }
 
 #[cfg(test)]

--- a/components/jetstream_rpc/src/subscription.rs
+++ b/components/jetstream_rpc/src/subscription.rs
@@ -283,7 +283,16 @@ pub struct Labelled<K, T, D> {
 }
 
 impl<K: Clone + Unpin, T, D> futures::Stream for Labelled<K, T, D> {
-    type Item = jetstream_error::Result<(K, Item<T, D>)>;
+    /// The key accompanies the failure as well as the item.
+    ///
+    /// r[impl jetstream.subscription.surface.composition]
+    /// This used to yield a bare `Err`, which throws away the one thing
+    /// `Labelled` exists to keep. In a fan-in over several rooms, a
+    /// transport failure, a decode failure or a producer failure ends
+    /// one input and the caller could not tell which — so it could
+    /// neither retry that room nor report it, which is the same loss the
+    /// rule forbids for the *successful* end.
+    type Item = (K, jetstream_error::Result<Item<T, D>>);
 
     fn poll_next(
         self: std::pin::Pin<&mut Self>,
@@ -293,8 +302,7 @@ impl<K: Clone + Unpin, T, D> futures::Stream for Labelled<K, T, D> {
         let this = self.get_mut();
         let key = this.key.clone();
         match std::pin::Pin::new(&mut this.inner).poll_next(cx) {
-            Poll::Ready(Some(Ok(item))) => Poll::Ready(Some(Ok((key, item)))),
-            Poll::Ready(Some(Err(e))) => Poll::Ready(Some(Err(e))),
+            Poll::Ready(Some(result)) => Poll::Ready(Some((key, result))),
             Poll::Ready(None) => Poll::Ready(None),
             Poll::Pending => Poll::Pending,
         }

--- a/components/jetstream_rpc/src/subscription.rs
+++ b/components/jetstream_rpc/src/subscription.rs
@@ -222,7 +222,7 @@ where
     /// Build one from the frames of a streaming call. `decode` is the
     /// generated protocol's: only it knows which response variant is an
     /// item and which is the terminator.
-    pub fn from_frames<P, F>(stream: crate::RpcStream<P>, mut decode: F) -> Self
+    pub fn from_frames<P, F>(stream: crate::RpcStream<P>, decode: F) -> Self
     where
         P: crate::Protocol + 'static,
         P::Response: 'static,

--- a/components/jetstream_rpc/src/subscription.rs
+++ b/components/jetstream_rpc/src/subscription.rs
@@ -233,8 +233,28 @@ where
             + 'static,
     {
         use futures::StreamExt;
+        // r[impl jetstream.subscription.surface.termination]
+        // An ending is the last thing the subscription says. Mapping
+        // each frame and leaving the stream running let a failure be
+        // followed by more items, or even by a normal terminator — so a
+        // subscriber could be told its subscription had failed and then
+        // go on hearing from it. Through `merge` that is starker still:
+        // an input reported as failed keeps speaking under the same key.
         Subscription {
-            items: Box::pin(stream.map(move |frame| decode(frame?))),
+            items: Box::pin(futures::stream::unfold(
+                (stream, decode, false),
+                move |(mut stream, mut decode, finished)| async move {
+                    if finished {
+                        return None;
+                    }
+                    let item = match stream.next().await? {
+                        Ok(frame) => decode(frame),
+                        Err(e) => Err(e),
+                    };
+                    let finished = matches!(item, Err(_) | Ok(Item::Done(_)));
+                    Some((item, (stream, decode, finished)))
+                },
+            )),
         }
     }
 
@@ -354,7 +374,7 @@ pub use tokio_util::sync::CancellationToken;
 /// await, a flag to test, and a send that fails once cancelled. A loop
 /// that checks none of them still stops at its next `send`.
 pub struct Producer<T, D> {
-    tx: tokio::sync::mpsc::Sender<Item<T, D>>,
+    tx: tokio::sync::mpsc::Sender<jetstream_error::Result<Item<T, D>>>,
     cancel: tokio_util::sync::CancellationToken,
 }
 
@@ -365,7 +385,7 @@ impl<T, D> Producer<T, D> {
         tokio::select! {
             biased;
             _ = self.cancel.cancelled() => Err(Cancelled),
-            sent = self.tx.send(Item::Next(item)) => {
+            sent = self.tx.send(Ok(Item::Next(item))) => {
                 sent.map_err(|_| Cancelled)
             }
         }
@@ -375,7 +395,26 @@ impl<T, D> Producer<T, D> {
     /// End the subscription, carrying the result. Consuming `self` is
     /// the point: a producer that has finished cannot emit again.
     pub async fn finish(self, done: D) {
-        let _ = self.tx.send(Item::Done(done)).await;
+        let _ = self.tx.send(Ok(Item::Done(done))).await;
+    }
+
+    /// r[impl jetstream.subscription.surface.termination]
+    /// End the subscription because the work failed.
+    ///
+    /// Without this a producer had no way to say so. Returning early —
+    /// the `?` in any ordinary producer loop — drops the `Producer`,
+    /// which closes the channel, which the dispatcher reads as a
+    /// subscription that simply stopped: it then supplies the terminator
+    /// the caller is owed, and the subscriber receives a normal typed
+    /// ending carrying a *fabricated* result. A failure reported as
+    /// success is the one outcome the surface must never produce, so the
+    /// channel carries failures and this is how one is sent.
+    ///
+    /// Dropping without calling either this or `finish` remains the
+    /// cancelled case, which is what the dispatcher's synthetic
+    /// terminator is for.
+    pub async fn fail(self, error: jetstream_error::Error) {
+        let _ = self.tx.send(Err(error)).await;
     }
 
     pub fn is_cancelled(&self) -> bool {
@@ -397,11 +436,11 @@ impl<T, D> Producer<T, D> {
 
 /// The served side of a subscription: what the producer writes into.
 pub struct Items<T, D> {
-    rx: tokio::sync::mpsc::Receiver<Item<T, D>>,
+    rx: tokio::sync::mpsc::Receiver<jetstream_error::Result<Item<T, D>>>,
 }
 
 impl<T, D> futures::Stream for Items<T, D> {
-    type Item = Item<T, D>;
+    type Item = jetstream_error::Result<Item<T, D>>;
 
     fn poll_next(
         mut self: std::pin::Pin<&mut Self>,
@@ -427,9 +466,15 @@ where
         P: crate::Protocol + 'static,
         P::Response: 'static,
         P::Error: 'static,
-        F: FnMut(Item<T, D>) -> P::Response + Send + 'static,
+        F: FnMut(jetstream_error::Result<Item<T, D>>) -> P::Response
+            + Send
+            + 'static,
     {
         use futures::StreamExt;
+        // `encode` sees the failure too, because only the protocol knows
+        // how to say "this subscription failed" in its own response
+        // type. Yielding `Err` here instead would make it a *transport*
+        // error, which tears down the lane and every other call on it.
         Box::pin(self.map(move |item| {
             Ok(crate::Frame {
                 tag,

--- a/components/jetstream_rpc/src/subscription/tests.rs
+++ b/components/jetstream_rpc/src/subscription/tests.rs
@@ -86,3 +86,161 @@ fn an_endpoint_is_opaque_bytes() {
     let binary = Endpoint(Data(vec![0xff, 0x00, 0xfe]));
     assert_eq!(Endpoint::from_bytes(&binary.to_bytes()).unwrap(), binary);
 }
+
+// ---------------------------------------------------------------------------
+// The typed surface.
+
+use futures::StreamExt;
+
+use super::{channel, merge, Item, Subscription, Terminator};
+
+/// r[impl jetstream.subscription.surface.terminal-value]
+/// The end carries a value. A `Stream` alone ends with `None`, which is
+/// where the first attempt at this surface stopped: `Subscription<Event>`
+/// offered no `result()` and could not be given one.
+#[tokio::test]
+async fn the_end_carries_a_value() {
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let (producer, items) = channel::<u32, String>(8, cancel);
+    tokio::spawn(async move {
+        producer.send(1).await.unwrap();
+        producer.send(2).await.unwrap();
+        producer.finish("two messages".to_string()).await;
+    });
+
+    let got: Vec<Item<u32, String>> = items.collect().await;
+    assert_eq!(
+        got,
+        vec![
+            Item::Next(1),
+            Item::Next(2),
+            Item::Done("two messages".to_string())
+        ]
+    );
+}
+
+/// r[impl jetstream.subscription.surface.producer]
+/// A producer that watches nothing still stops, because the send is the
+/// third of the three forms the rule allows. The loop below is the one
+/// that used to run forever.
+#[tokio::test]
+async fn a_producer_that_watches_nothing_still_stops() {
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let (producer, mut items) = channel::<u32, ()>(1, cancel.clone());
+    let looping = tokio::spawn(async move {
+        let mut sent = 0u32;
+        // No `is_cancelled`, no `cancelled().await`. Just work and send.
+        while producer.send(sent).await.is_ok() {
+            sent += 1;
+        }
+        sent
+    });
+
+    assert_eq!(items.next().await, Some(Item::Next(0)));
+    cancel.cancel();
+    drop(items);
+
+    let sent = tokio::time::timeout(std::time::Duration::from_secs(5), looping)
+        .await
+        .expect("a cancelled producer must stop at its next send")
+        .unwrap();
+    assert!(sent < 1_000, "it stopped rather than ran on: {sent}");
+}
+
+/// r[impl jetstream.subscription.surface.producer]
+/// And a producer that *does* watch can stop between items, which is
+/// what a subscription whose work is expensive needs.
+#[tokio::test]
+async fn a_producer_can_watch_for_cancellation() {
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let (producer, _items) = channel::<u32, ()>(8, cancel.clone());
+    assert!(!producer.is_cancelled());
+    cancel.cancel();
+    assert!(producer.is_cancelled());
+    tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        producer.cancelled(),
+    )
+    .await
+    .expect("the awaited signal must fire too");
+}
+
+fn finite(items: Vec<u32>, done: &str) -> Subscription<u32, String> {
+    let done = done.to_string();
+    Subscription::from_items(futures::stream::iter(
+        items
+            .into_iter()
+            .map(Item::Next)
+            .chain(std::iter::once(Item::Done(done)))
+            .map(Ok),
+    ))
+}
+
+/// r[impl jetstream.subscription.surface.composition]
+/// Fan-in without losing the ends. `select_all` over bare item streams
+/// yields every item and no terminator, and cannot say which sequence
+/// finished — use case 2 and use case 4 are each satisfiable alone and
+/// were not satisfiable together.
+#[tokio::test]
+async fn merging_keeps_every_terminator_and_says_whose() {
+    let merged = merge([
+        ("east", finite(vec![1, 2], "east closed")),
+        ("west", finite(vec![3], "west closed")),
+    ]);
+
+    let mut items: Vec<(&str, u32)> = Vec::new();
+    let mut ends: Vec<(&str, String)> = Vec::new();
+    let mut merged = merged;
+    while let Some(next) = merged.next().await {
+        match next.unwrap() {
+            (who, Item::Next(n)) => items.push((who, n)),
+            (who, Item::Done(why)) => ends.push((who, why)),
+        }
+    }
+
+    items.sort();
+    ends.sort();
+    assert_eq!(items, vec![("east", 1), ("east", 2), ("west", 3)]);
+    assert_eq!(
+        ends,
+        vec![
+            ("east", "east closed".to_string()),
+            ("west", "west closed".to_string())
+        ],
+        "both ends must survive the merge, and be attributable"
+    );
+}
+
+/// r[impl jetstream.subscription.termination]
+/// Two subscriptions on one protocol have two terminal types under one
+/// global `RDONE`. The payload names its method, so a decoder that never
+/// sees the tag can still tell them apart.
+#[test]
+fn a_typed_terminator_names_its_method() {
+    let closed = Terminator {
+        method: 102,
+        value: 7u32,
+    };
+    let other = Terminator {
+        method: 104,
+        value: 7u32,
+    };
+    assert_ne!(encoded(&closed), encoded(&other));
+
+    let mut bytes = encoded(&closed);
+    let round: Terminator<u32> =
+        WireFormat::decode(&mut bytes.as_slice()).unwrap();
+    assert_eq!(round, closed);
+    assert_eq!(
+        closed.byte_size() as usize,
+        bytes.len(),
+        "the discriminant costs exactly one byte"
+    );
+    bytes.clear();
+}
+
+fn encoded<T: WireFormat>(v: &T) -> Vec<u8> {
+    let mut out = Vec::new();
+    v.encode(&mut out).unwrap();
+    out
+}

--- a/components/jetstream_rpc/src/subscription/tests.rs
+++ b/components/jetstream_rpc/src/subscription/tests.rs
@@ -108,7 +108,10 @@ async fn the_end_carries_a_value() {
         producer.finish("two messages".to_string()).await;
     });
 
-    let got: Vec<Item<u32, String>> = items.collect().await;
+    let got: Vec<Item<u32, String>> = items
+        .map(|item| item.expect("this producer does not fail"))
+        .collect()
+        .await;
     assert_eq!(
         got,
         vec![
@@ -136,7 +139,7 @@ async fn a_producer_that_watches_nothing_still_stops() {
         sent
     });
 
-    assert_eq!(items.next().await, Some(Item::Next(0)));
+    assert_eq!(items.next().await.map(|i| i.unwrap()), Some(Item::Next(0)));
     cancel.cancel();
     drop(items);
 
@@ -275,4 +278,41 @@ async fn merging_says_which_subscription_failed() {
     assert_eq!(failures.len(), 1, "exactly one input failed");
     assert_eq!(failures[0].0, "west", "and the caller can tell which");
     assert!(failures[0].1.contains("the room went away"));
+}
+
+/// r[impl jetstream.subscription.surface.termination]
+/// A producer that fails must be able to say so. Before the channel
+/// carried failures it could not: returning early — the `?` in any
+/// ordinary producer loop — dropped the `Producer`, closing the channel,
+/// which the dispatcher reads as a subscription that merely stopped. It
+/// then supplies the terminator the caller is owed, and the subscriber
+/// receives a normal typed ending carrying a *fabricated* result. A
+/// failure reported as success is the one outcome the surface must never
+/// produce.
+#[tokio::test]
+async fn a_failed_producer_does_not_report_a_normal_ending() {
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let (producer, items) = channel::<u32, String>(8, cancel);
+    tokio::spawn(async move {
+        producer.send(1).await.unwrap();
+        producer
+            .fail(jetstream_error::Error::new("the feed went away"))
+            .await;
+    });
+
+    let got: Vec<_> = items.collect().await;
+    assert!(
+        matches!(got.first(), Some(Ok(Item::Next(1)))),
+        "the item before the failure still arrives: {got:?}",
+    );
+    let last = got.last().expect("the failure is an item in the sequence");
+    assert!(
+        last.is_err(),
+        "the sequence must end in the failure, not in silence: {got:?}",
+    );
+    assert!(
+        !got.iter().any(|i| matches!(i, Ok(Item::Done(_)))),
+        "a failure must never be dressed up as a completed subscription: \
+         {got:?}",
+    );
 }

--- a/components/jetstream_rpc/src/subscription/tests.rs
+++ b/components/jetstream_rpc/src/subscription/tests.rs
@@ -192,9 +192,10 @@ async fn merging_keeps_every_terminator_and_says_whose() {
     let mut ends: Vec<(&str, String)> = Vec::new();
     let mut merged = merged;
     while let Some(next) = merged.next().await {
-        match next.unwrap() {
-            (who, Item::Next(n)) => items.push((who, n)),
-            (who, Item::Done(why)) => ends.push((who, why)),
+        match next {
+            (who, Ok(Item::Next(n))) => items.push((who, n)),
+            (who, Ok(Item::Done(why))) => ends.push((who, why)),
+            (who, Err(e)) => panic!("{who} failed unexpectedly: {e}"),
         }
     }
 
@@ -243,4 +244,35 @@ fn encoded<T: WireFormat>(v: &T) -> Vec<u8> {
     let mut out = Vec::new();
     v.encode(&mut out).unwrap();
     out
+}
+
+/// r[impl jetstream.subscription.surface.composition]
+/// A failure keeps its key too.
+///
+/// Merging discarded the key on `Err`, so in a fan-in over several rooms
+/// a caller could see that *something* failed and not which — it could
+/// neither retry that room nor report it. That is the same loss the rule
+/// forbids for a successful end, and it went unnoticed because every
+/// test merged subscriptions that only succeed.
+#[tokio::test]
+async fn merging_says_which_subscription_failed() {
+    let failing: Subscription<u32, String> =
+        Subscription::from_items(futures::stream::iter(vec![
+            Ok(Item::Next(1)),
+            Err(jetstream_error::Error::new("the room went away")),
+        ]));
+    let merged =
+        merge([("east", finite(vec![9], "east closed")), ("west", failing)]);
+
+    let mut failures: Vec<(&str, String)> = Vec::new();
+    let mut merged = merged;
+    while let Some((who, result)) = merged.next().await {
+        if let Err(e) = result {
+            failures.push((who, e.to_string()));
+        }
+    }
+
+    assert_eq!(failures.len(), 1, "exactly one input failed");
+    assert_eq!(failures[0].0, "west", "and the caller can tell which");
+    assert!(failures[0].1.contains("the room went away"));
 }

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -1,5 +1,6 @@
 - [JetStream](0intro.md)
 - [Sessions and Lanes](sessions.md)
+- [Subscriptions](subscriptions.md)
 - [🌐 Iroh](iroh.md)
 - [🚀 QUIC](quic.md)
 - [🌍 HTTP](http.md)

--- a/docs/subscriptions.md
+++ b/docs/subscriptions.md
@@ -1,0 +1,120 @@
+# Subscriptions
+
+A **subscription** is a streaming response: one request, many responses
+sharing its tag, terminated explicitly.
+
+That is the whole shape. It adds no new role — the subscriber is still the
+caller, the producer is still the service — and no new transport
+requirement: a subscription is realisable on any session JetStream
+supports, including one with a single lane.
+
+The normative rules live in
+[the subscriptions specification](https://github.com/sevki/jetstream/blob/main/docs/specs/subscriptions.md).
+This page is the guide to using them.
+
+## Why not a reverse call
+
+The obvious way to let a service push is to make it the caller — open a
+lane the other way and let the service issue requests. JetStream does not,
+and the reason is not that it cannot: it is that the subscriber then has
+no correlation key to cancel by, no place to put backpressure that the
+producer can see, and nothing that ends. A subscription keeps all three by
+staying a call: the tag that identifies the request identifies the
+subscription for as long as it lives, and the terminator that frees the
+tag is the thing that ended.
+
+The cost is that a live subscription holds a tag for its whole life. That
+is real, and the specification counts it.
+
+## Three things the shape has to get right
+
+**The end is a value.** A subscription that reports on an operation — an
+upload, a build, a room closing — has a *result*, and a sequence that ends
+with the absence of an item has nowhere to put one. So the terminator is
+an `Item::Done(_)` in the sequence rather than the sequence stopping:
+
+```rust,ignore
+while let Some(item) = events.next().await {
+    match item? {
+        Item::Next(event) => render(event),
+        Item::Done(closed) => return Ok(closed.last_seq),
+    }
+}
+```
+
+This is also what makes fan-in work. `select_all` yields items and drops a
+finished stream silently, so merging subscriptions whose end was `None`
+shows every item and no ending at all. `subscription::merge` labels each
+one, so a merged consumer can still say *which* ended and with what.
+
+**Cancelling reaches the work.** Dropping a subscription is how a Rust
+caller cancels, and it must stop the producer, not merely stop reading it.
+Dropping sends a cancellation naming the subscription's tag; the
+dispatcher cancels the token the producer holds; the producer's next
+`send` fails even if it watches nothing else. A producer that does watch
+can stop between items:
+
+```rust,ignore
+tokio::select! {
+    _ = producer.cancelled() => break,
+    next = expensive_inference() => producer.send(next).await?,
+}
+```
+
+**A subscription does not take its lane.** A room that stays open is the
+normal case, and a dispatcher that serves a subscription by consuming it
+never reads that lane again — no second request served, and no
+cancellation able to arrive. `server::run` serves the subscriptions in
+flight *and* the requests still arriving, together.
+
+## A room
+
+The example below is a chat room: one room, many subscribers, no transport
+in the protocol. It runs over a `LocalSession`; the same code runs over
+QUIC, iroh or WebTransport, because what it needs from a session is lanes
+and nothing else.
+
+The protocol is written by hand. `#[service]` will generate all of it —
+this is what it has to generate.
+
+```console
+cargo run --example chat_room
+```
+
+```text
+joined room-42
+producers alive: 3
+posted #1
+  heard: ada says is anyone there?
+  heard: ada says is anyone there?
+producers alive after one left: 2
+  ada heard: grace says here
+  grace heard: grace says here
+  ada's subscription closed at #2
+  grace's subscription closed at #2
+producers alive at the end: 0
+```
+
+Three lines in that output are the three rules above. `posted #1` arrives
+while all three subscriptions are open. `producers alive after one left:
+2` is a dropped subscription stopping the work behind it, not just the
+delivery. And `closed at #2` is a result carried out through a merge and
+still attributable to the subscriber that received it.
+
+```rust,ignore
+{{#include ../examples/chat_room.rs}}
+```
+
+## Realisation
+
+Nothing in the caller's type says whether a subscription got a lane of its
+own or a tag on a lane it shares. On a session reporting
+`LaneSupport::Many` the example opens one lane per subscription, for
+independent flow control; on a session with one lane the same code
+tag-multiplexes. That choice belongs to the session, and a caller that had
+to branch on it would not have had the transport abstracted, only
+reported.
+
+Which is also why a channel is built over a **session** rather than over a
+lane. A channel handed one transport can only ever tag-multiplex, so the
+caller's construction would have made the realisation choice.

--- a/examples/chat_room.rs
+++ b/examples/chat_room.rs
@@ -87,6 +87,12 @@ pub enum Say {
     Event(Event),
     Done(Terminator<Closed>),
     Ack(Rcancel),
+    /// r[impl jetstream.subscription.surface.termination]
+    /// The room failed. A failure has to be a *response* under the
+    /// subscription's tag, not a transport error: the latter tears down
+    /// the lane and everything else on it, and the subscriber never
+    /// learns what happened to the one call it made.
+    Error(Error),
 }
 
 impl Framer for Ask {
@@ -134,6 +140,7 @@ impl Framer for Say {
             Say::Event(_) => REVENT,
             Say::Done(_) => RDONE,
             Say::Ack(_) => RCANCEL,
+            Say::Error(_) => RJETSTREAMERROR,
         }
     }
 
@@ -143,6 +150,7 @@ impl Framer for Say {
             Say::Event(e) => e.byte_size(),
             Say::Done(d) => d.byte_size(),
             Say::Ack(a) => a.byte_size(),
+            Say::Error(e) => e.byte_size(),
         }
     }
 
@@ -152,6 +160,7 @@ impl Framer for Say {
             Say::Event(e) => e.encode(w),
             Say::Done(d) => d.encode(w),
             Say::Ack(a) => a.encode(w),
+            Say::Error(e) => e.encode(w),
         }
     }
 
@@ -165,6 +174,7 @@ impl Framer for Say {
             // yet; with two there would be.
             RDONE => Ok(Say::Done(WireFormat::decode(r)?)),
             RCANCEL => Ok(Say::Ack(WireFormat::decode(r)?)),
+            RJETSTREAMERROR => Ok(Say::Error(WireFormat::decode(r)?)),
             other => Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 format!("unknown response type {other}"),
@@ -323,11 +333,13 @@ impl Server for ChatRoom {
         });
 
         items.into_frames::<Self, _>(tag, move |item| match item {
-            subscription::Item::Next(event) => Say::Event(event),
-            subscription::Item::Done(closed) => Say::Done(Terminator {
+            Ok(subscription::Item::Next(event)) => Say::Event(event),
+            Ok(subscription::Item::Done(closed)) => Say::Done(Terminator {
                 method: TEVENTS,
                 value: closed,
             }),
+            // Only this room's subscriber hears about it.
+            Err(err) => Say::Error(err),
         })
     }
 }

--- a/examples/chat_room.rs
+++ b/examples/chat_room.rs
@@ -1,0 +1,511 @@
+//! A chat room, the way a Durable Object would host one.
+//!
+//! One room, many subscribers, and no transport anywhere in the
+//! protocol. The room is served over a `LocalSession` here; the same
+//! code serves over QUIC, iroh or WebTransport, because what it needs
+//! from a session is lanes and nothing else.
+//!
+//! A **subscription** is one request and many responses sharing its tag,
+//! terminated explicitly. The three things that makes hard, and that
+//! this example is really about:
+//!
+//! * the end is a *value* — `Item::Done(Closed { last_seq })` — so a
+//!   subscription can report a result, and so the end survives a merge;
+//! * cancelling reaches the *producer*, not just the delivery, so
+//!   dropping a subscription stops the work behind it;
+//! * a subscription does not take the lane it is served on, so `post`
+//!   still works while every subscriber is listening.
+//!
+//! The protocol here is written by hand. `#[service]` will generate all
+//! of it — this is what it has to generate.
+//!
+//! ```console
+//! cargo run --example chat_room
+//! ```
+
+use std::{
+    io,
+    sync::{
+        atomic::{AtomicU64, AtomicUsize, Ordering::SeqCst},
+        Arc,
+    },
+};
+
+use futures::StreamExt;
+use jetstream::prelude::*;
+use jetstream_rpc::{
+    server::ResponseStream,
+    session::{LocalSession, Session},
+    subscription::{
+        self, CancellationToken, Rcancel, Tcancel, Terminator, RCANCEL, RDONE,
+        TCANCEL,
+    },
+    Mux,
+};
+use tokio::sync::broadcast;
+
+// ---------------------------------------------------------------------------
+// The wire types. Two methods, so two request ids in the per-method
+// space: 102 + 2 * index. The terminator and the cancellation take the
+// global ids, which is what keeps that arithmetic intact.
+
+const TPOST: u8 = 102;
+const RPOST: u8 = 103;
+const TEVENTS: u8 = 104;
+const REVENT: u8 = 105;
+
+#[derive(Debug, Clone, JetStreamWireFormat)]
+pub struct Event {
+    pub seq: u64,
+    pub who: String,
+    pub body: String,
+}
+
+/// What the room says when a subscription ends normally. This is the
+/// value that has nowhere to live in a plain `Stream`.
+#[derive(Debug, Clone, JetStreamWireFormat)]
+pub struct Closed {
+    pub last_seq: u64,
+}
+
+#[derive(Debug, Clone, JetStreamWireFormat)]
+pub struct Post {
+    pub who: String,
+    pub body: String,
+}
+
+#[derive(Debug)]
+pub enum Ask {
+    Post(Post),
+    Events(u64),
+    Cancel(Tcancel),
+}
+
+#[derive(Debug)]
+pub enum Say {
+    Posted(u64),
+    Event(Event),
+    Done(Terminator<Closed>),
+    Ack(Rcancel),
+}
+
+impl Framer for Ask {
+    fn message_type(&self) -> u8 {
+        match self {
+            Ask::Post(_) => TPOST,
+            Ask::Events(_) => TEVENTS,
+            Ask::Cancel(_) => TCANCEL,
+        }
+    }
+
+    fn byte_size(&self) -> u32 {
+        match self {
+            Ask::Post(p) => p.byte_size(),
+            Ask::Events(f) => f.byte_size(),
+            Ask::Cancel(c) => c.byte_size(),
+        }
+    }
+
+    fn encode<W: io::Write>(&self, w: &mut W) -> io::Result<()> {
+        match self {
+            Ask::Post(p) => p.encode(w),
+            Ask::Events(f) => f.encode(w),
+            Ask::Cancel(c) => c.encode(w),
+        }
+    }
+
+    fn decode<R: io::Read>(r: &mut R, ty: u8) -> io::Result<Self> {
+        match ty {
+            TPOST => Ok(Ask::Post(WireFormat::decode(r)?)),
+            TEVENTS => Ok(Ask::Events(WireFormat::decode(r)?)),
+            TCANCEL => Ok(Ask::Cancel(WireFormat::decode(r)?)),
+            other => Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("unknown request type {other}"),
+            )),
+        }
+    }
+}
+
+impl Framer for Say {
+    fn message_type(&self) -> u8 {
+        match self {
+            Say::Posted(_) => RPOST,
+            Say::Event(_) => REVENT,
+            Say::Done(_) => RDONE,
+            Say::Ack(_) => RCANCEL,
+        }
+    }
+
+    fn byte_size(&self) -> u32 {
+        match self {
+            Say::Posted(s) => s.byte_size(),
+            Say::Event(e) => e.byte_size(),
+            Say::Done(d) => d.byte_size(),
+            Say::Ack(a) => a.byte_size(),
+        }
+    }
+
+    fn encode<W: io::Write>(&self, w: &mut W) -> io::Result<()> {
+        match self {
+            Say::Posted(s) => s.encode(w),
+            Say::Event(e) => e.encode(w),
+            Say::Done(d) => d.encode(w),
+            Say::Ack(a) => a.encode(w),
+        }
+    }
+
+    fn decode<R: io::Read>(r: &mut R, ty: u8) -> io::Result<Self> {
+        match ty {
+            RPOST => Ok(Say::Posted(WireFormat::decode(r)?)),
+            REVENT => Ok(Say::Event(WireFormat::decode(r)?)),
+            // The terminator's payload names its method, because `RDONE`
+            // is one global id and a decoder never sees the tag. With
+            // one subscription method there is nothing to tell apart
+            // yet; with two there would be.
+            RDONE => Ok(Say::Done(WireFormat::decode(r)?)),
+            RCANCEL => Ok(Say::Ack(WireFormat::decode(r)?)),
+            other => Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("unknown response type {other}"),
+            )),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct Room;
+
+impl Protocol for Room {
+    type Error = Error;
+    type Request = Ask;
+    type Response = Say;
+
+    const NAME: &'static str = "room";
+    const VERSION: &'static str = "rs.jetstream.proto/room/0.1.0";
+
+    fn tcancel(oldtag: u16, binding: u64) -> Option<Ask> {
+        Some(Ask::Cancel(Tcancel { oldtag, binding }))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The service.
+
+#[derive(Clone)]
+struct ChatRoom {
+    events: broadcast::Sender<Event>,
+    seq: Arc<AtomicU64>,
+    /// Cancelled when the room itself closes, which is the *other* way a
+    /// subscription ends — and the one that carries a result.
+    closing: CancellationToken,
+    /// How many producers are alive. The example prints it to show that
+    /// cancelling a subscription stops the work, rather than leaving it
+    /// running with nowhere to deliver.
+    producers: Arc<AtomicUsize>,
+}
+
+impl Protocol for ChatRoom {
+    type Error = Error;
+    type Request = Ask;
+    type Response = Say;
+
+    const NAME: &'static str = Room::NAME;
+    const VERSION: &'static str = Room::VERSION;
+
+    fn tcancel(oldtag: u16, binding: u64) -> Option<Ask> {
+        Room::tcancel(oldtag, binding)
+    }
+}
+
+impl Server for ChatRoom {
+    fn is_streaming(message_type: u8) -> bool {
+        message_type == TEVENTS
+    }
+
+    fn cancel_target(frame: &Frame<Ask>) -> Option<u16> {
+        match &frame.msg {
+            Ask::Cancel(c) => Some(c.oldtag),
+            _ => None,
+        }
+    }
+
+    fn cancel_ack(oldtag: u16) -> Option<Say> {
+        Some(Say::Ack(Rcancel { oldtag }))
+    }
+
+    fn cancelled_terminator() -> Option<Say> {
+        Some(Say::Done(Terminator {
+            method: TEVENTS,
+            value: Closed { last_seq: 0 },
+        }))
+    }
+
+    async fn rpc(
+        &mut self,
+        _ctx: Context,
+        frame: Frame<Ask>,
+    ) -> std::result::Result<Frame<Say>, Error> {
+        match frame.msg {
+            Ask::Post(post) => {
+                let seq = self.seq.fetch_add(1, SeqCst) + 1;
+                // A subscriber that has gone is not an error here: the
+                // room does not know or care who is listening.
+                let _ = self.events.send(Event {
+                    seq,
+                    who: post.who,
+                    body: post.body,
+                });
+                Ok(Frame {
+                    tag: frame.tag,
+                    msg: Say::Posted(seq),
+                })
+            }
+            other => Err(Error::new(format!("not a unary method: {other:?}"))),
+        }
+    }
+
+    async fn rpc_stream(
+        &mut self,
+        _ctx: Context,
+        frame: Frame<Ask>,
+        cancel: CancellationToken,
+    ) -> ResponseStream<Self> {
+        let tag = frame.tag;
+        let from = match frame.msg {
+            Ask::Events(from) => from,
+            _ => 0,
+        };
+
+        // The producer's end. It can send *and* learn that its
+        // subscriber has gone — the half a bare `Sender` cannot do.
+        let (producer, items) =
+            subscription::channel::<Event, Closed>(64, cancel);
+        let stop = producer.cancellation();
+        let mut feed = self.events.subscribe();
+        let seq = self.seq.clone();
+        let closing = self.closing.clone();
+        let producers = self.producers.clone();
+        producers.fetch_add(1, SeqCst);
+
+        tokio::spawn(async move {
+            let ending = loop {
+                tokio::select! {
+                    // The subscriber went away. Stop the work; there is
+                    // no result to report to someone who is not there.
+                    _ = stop.cancelled() => break None,
+                    // The room closed. That *is* a result.
+                    _ = closing.cancelled() => {
+                        break Some(Closed { last_seq: seq.load(SeqCst) });
+                    }
+                    got = feed.recv() => match got {
+                        Ok(event) => {
+                            if event.seq >= from
+                                && producer.send(event).await.is_err()
+                            {
+                                break None;
+                            }
+                        }
+                        Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                        Err(_) => {
+                            break Some(Closed { last_seq: seq.load(SeqCst) })
+                        }
+                    },
+                }
+            };
+            if let Some(closed) = ending {
+                producer.finish(closed).await;
+            }
+            producers.fetch_sub(1, SeqCst);
+        });
+
+        items.into_frames::<Self, _>(tag, move |item| match item {
+            subscription::Item::Next(event) => Say::Event(event),
+            subscription::Item::Done(closed) => Say::Done(Terminator {
+                method: TEVENTS,
+                value: closed,
+            }),
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The client.
+
+/// Built over the **session**, not over a lane — a channel handed one
+/// transport can only tag-multiplex, which would make the caller's
+/// construction the realisation choice.
+struct RoomChannel {
+    session: LocalSession<Room>,
+    endpoint: Endpoint,
+    unary: Mux<Room>,
+}
+
+impl RoomChannel {
+    async fn over(
+        session: LocalSession<Room>,
+        endpoint: Endpoint,
+    ) -> std::result::Result<Self, Box<dyn std::error::Error>> {
+        let lane = Session::<Room>::open_lane(&session).await?;
+        Ok(RoomChannel {
+            session,
+            endpoint,
+            unary: Mux::new(64, Box::new(lane)),
+        })
+    }
+
+    async fn post(
+        &self,
+        who: &str,
+        body: &str,
+    ) -> std::result::Result<u64, Error> {
+        let answer = self
+            .unary
+            .rpc(
+                Context::default(),
+                Ask::Post(Post {
+                    who: who.to_string(),
+                    body: body.to_string(),
+                }),
+            )
+            .await
+            .await?;
+        match answer.msg {
+            Say::Posted(seq) => Ok(seq),
+            other => Err(Error::new(format!("unexpected answer: {other:?}"))),
+        }
+    }
+
+    /// A lane of its own, because this session has many — the choice
+    /// `Capability::ManyLanes` licenses and that the caller never sees.
+    /// On a session with one lane this would be a tag on the shared one,
+    /// and the type below would be the same.
+    async fn events(
+        &self,
+        from: u64,
+    ) -> std::result::Result<
+        Subscription<Event, Closed>,
+        Box<dyn std::error::Error>,
+    > {
+        let lane = Session::<Room>::open_lane(&self.session).await?;
+        let mux = Mux::<Room>::new(64, Box::new(lane));
+        let frames = mux
+            .rpc_stream(Context::default(), Ask::Events(from), 64)
+            .await;
+        Ok(Subscription::from_frames(frames, move |frame| {
+            // The lane's multiplexer has to outlive the subscription
+            // reading through it, so it rides along in this closure.
+            let _ = &mux;
+            match frame.msg {
+                Say::Event(event) => Ok(Item::Next(event)),
+                Say::Done(done) => Ok(Item::Done(done.value)),
+                other => Err(Error::new(format!("unexpected item: {other:?}"))),
+            }
+        }))
+    }
+
+    fn endpoint(&self) -> &Endpoint {
+        &self.endpoint
+    }
+}
+
+// ---------------------------------------------------------------------------
+
+#[tokio::main]
+async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
+    let pair = LocalSession::<Room>::pair();
+
+    let room = ChatRoom {
+        events: broadcast::channel(256).0,
+        seq: Arc::new(AtomicU64::new(0)),
+        closing: CancellationToken::new(),
+        producers: Arc::new(AtomicUsize::new(0)),
+    };
+    let producers = room.producers.clone();
+    let closing = room.closing.clone();
+
+    // One task per lane. A lane is a `ServiceTransport`, so it goes
+    // straight into the RPC loop with no adapter in between.
+    let serving = {
+        let server = pair.server.clone();
+        tokio::spawn(async move {
+            while let Ok(lane) = Session::<Room>::accept_lane(&server).await {
+                let mut room = room.clone();
+                tokio::spawn(async move {
+                    let _ = jetstream_rpc::server::run(&mut room, lane).await;
+                });
+            }
+        })
+    };
+
+    let channel =
+        RoomChannel::over(pair.client.clone(), Endpoint::from("room-42"))
+            .await?;
+    println!(
+        "joined {}",
+        String::from_utf8_lossy(channel.endpoint().as_bytes())
+    );
+
+    // Two subscribers, and a third that leaves early.
+    let mut ada = channel.events(0).await?;
+    let mut grace = channel.events(0).await?;
+    let leaving = channel.events(0).await?;
+    settle().await;
+    println!("producers alive: {}", producers.load(SeqCst));
+
+    // A subscription is one call among the lane's others. This used to
+    // hang: the dispatcher served a subscription by consuming it, and
+    // never read the lane again.
+    let seq = channel.post("ada", "is anyone there?").await?;
+    println!("posted #{seq}");
+
+    for who in [&mut ada, &mut grace] {
+        match who.next().await.expect("an event")? {
+            Item::Next(event) => {
+                println!("  heard: {} says {}", event.who, event.body)
+            }
+            Item::Done(_) => panic!("not yet"),
+        }
+    }
+
+    // Dropping a subscription cancels it, and cancelling reaches the
+    // work: the producer behind it stops, rather than carrying on with
+    // nowhere to deliver.
+    drop(leaving);
+    settle().await;
+    println!("producers alive after one left: {}", producers.load(SeqCst));
+
+    // Closing the room ends every subscription with a *result*. This is
+    // the value a plain `Stream` has nowhere to put.
+    channel.post("grace", "here").await?;
+    closing.cancel();
+
+    // Fan-in: merged, and still able to say which subscription ended and
+    // with what. `select_all` over bare item streams would show every
+    // event and no ending at all.
+    let mut merged = subscription::merge([("ada", ada), ("grace", grace)]);
+    while let Some(next) = merged.next().await {
+        match next? {
+            (who, Item::Next(event)) => {
+                println!("  {who} heard: {} says {}", event.who, event.body)
+            }
+            (who, Item::Done(closed)) => {
+                println!(
+                    "  {who}'s subscription closed at #{}",
+                    closed.last_seq
+                )
+            }
+        }
+    }
+
+    settle().await;
+    println!("producers alive at the end: {}", producers.load(SeqCst));
+    serving.abort();
+    Ok(())
+}
+
+/// Let the spawned halves catch up. Everything here is in-process, so
+/// this is a scheduling nudge rather than a timeout.
+async fn settle() {
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+}

--- a/examples/chat_room.rs
+++ b/examples/chat_room.rs
@@ -234,9 +234,12 @@ impl Server for ChatRoom {
         Some(Say::Ack(Rcancel { oldtag }))
     }
 
-    fn cancelled_terminator() -> Option<Say> {
+    fn cancelled_terminator(method: u8) -> Option<Say> {
+        // One streaming method, so `method` can only be `TEVENTS` — but
+        // the terminator names it, so a second one would decode
+        // correctly without touching this.
         Some(Say::Done(Terminator {
-            method: TEVENTS,
+            method,
             value: Closed { last_seq: 0 },
         }))
     }

--- a/examples/chat_room.rs
+++ b/examples/chat_room.rs
@@ -341,7 +341,10 @@ impl Server for ChatRoom {
 struct RoomChannel {
     session: LocalSession<Room>,
     endpoint: Endpoint,
-    unary: Mux<Room>,
+    /// Shared, so a subscription can be opened on the same lane the
+    /// unary calls use — which is the arrangement that actually
+    /// exercises `jetstream.subscription.dispatch.concurrent`.
+    unary: std::sync::Arc<Mux<Room>>,
 }
 
 impl RoomChannel {
@@ -353,7 +356,7 @@ impl RoomChannel {
         Ok(RoomChannel {
             session,
             endpoint,
-            unary: Mux::new(64, Box::new(lane)),
+            unary: std::sync::Arc::new(Mux::new(64, Box::new(lane))),
         })
     }
 
@@ -379,10 +382,10 @@ impl RoomChannel {
         }
     }
 
-    /// A lane of its own, because this session has many — the choice
-    /// `Capability::ManyLanes` licenses and that the caller never sees.
-    /// On a session with one lane this would be a tag on the shared one,
-    /// and the type below would be the same.
+    /// A subscription on a lane of its own, because this session has
+    /// many — the choice `Capability::ManyLanes` licenses and that the
+    /// caller never sees. On a session with one lane this would be a tag
+    /// on the shared one, and the type below would be the same.
     async fn events(
         &self,
         from: u64,
@@ -391,11 +394,36 @@ impl RoomChannel {
         Box<dyn std::error::Error>,
     > {
         let lane = Session::<Room>::open_lane(&self.session).await?;
-        let mux = Mux::<Room>::new(64, Box::new(lane));
+        Ok(Self::events_on(
+            std::sync::Arc::new(Mux::<Room>::new(64, Box::new(lane))),
+            from,
+        )
+        .await)
+    }
+
+    /// A subscription on the multiplexer the caller already holds — that
+    /// is, **sharing a lane with its other calls**.
+    ///
+    /// This exists because the example was not demonstrating what it
+    /// claimed. Every subscription opened its own lane and `post` used
+    /// another, so `posted #1` proved only that a second lane works:
+    /// reverting the dispatcher fix would have printed it just the same,
+    /// with each subscription lane occupied forever and the unary lane
+    /// answering normally. Sharing a lane is the case
+    /// `jetstream.subscription.dispatch.concurrent` is actually about.
+    /// A subscription sharing the lane this channel's `post` uses.
+    async fn events_here(&self, from: u64) -> Subscription<Event, Closed> {
+        Self::events_on(self.unary.clone(), from).await
+    }
+
+    async fn events_on(
+        mux: std::sync::Arc<Mux<Room>>,
+        from: u64,
+    ) -> Subscription<Event, Closed> {
         let frames = mux
             .rpc_stream(Context::default(), Ask::Events(from), 64)
             .await;
-        Ok(Subscription::from_frames(frames, move |frame| {
+        Subscription::from_frames(frames, move |frame| {
             // The lane's multiplexer has to outlive the subscription
             // reading through it, so it rides along in this closure.
             let _ = &mux;
@@ -404,7 +432,7 @@ impl RoomChannel {
                 Say::Done(done) => Ok(Item::Done(done.value)),
                 other => Err(Error::new(format!("unexpected item: {other:?}"))),
             }
-        }))
+        })
     }
 
     fn endpoint(&self) -> &Endpoint {
@@ -449,8 +477,14 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
         String::from_utf8_lossy(channel.endpoint().as_bytes())
     );
 
-    // Two subscribers, and a third that leaves early.
-    let mut ada = channel.events(0).await?;
+    // Ada subscribes on the **same lane** the posts below go out on.
+    // With each subscription on its own lane, `posted #1` would print
+    // even with the dispatcher serving a subscription to exhaustion —
+    // the subscription lane would hang and the unary lane would answer
+    // regardless, which is what made the earlier version of this example
+    // decorative on its central claim.
+    let mut ada = channel.events_here(0).await;
+    // Grace gets a lane of her own, which is the other realisation.
     let mut grace = channel.events(0).await?;
     let leaving = channel.events(0).await?;
     settle().await;
@@ -488,16 +522,19 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     // event and no ending at all.
     let mut merged = subscription::merge([("ada", ada), ("grace", grace)]);
     while let Some(next) = merged.next().await {
-        match next? {
-            (who, Item::Next(event)) => {
+        match next {
+            (who, Ok(Item::Next(event))) => {
                 println!("  {who} heard: {} says {}", event.who, event.body)
             }
-            (who, Item::Done(closed)) => {
+            (who, Ok(Item::Done(closed))) => {
                 println!(
                     "  {who}'s subscription closed at #{}",
                     closed.last_seq
                 )
             }
+            // The key survives a failure too, so a fan-in can say which
+            // room went away rather than only that one did.
+            (who, Err(e)) => println!("  {who} failed: {e}"),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,9 +23,15 @@ pub mod prelude {
     pub use jetstream_error::*;
     pub use jetstream_macros::{service, JetStreamWireFormat};
     pub use jetstream_rpc::{
-        client, client::ClientTransport, context::Context, server,
-        server::Server, Error, Frame, Framed, Framer, Message, Mux, Protocol,
-        RpcCall, Rversion, TagPool, Tversion, Version, RJETSTREAMERROR,
+        client,
+        client::ClientTransport,
+        context::Context,
+        server,
+        server::Server,
+        subscription,
+        subscription::{Endpoint, Item, Subscription},
+        Error, Frame, Framed, Framer, Message, Mux, Protocol, RpcCall,
+        RpcStream, Rversion, TagPool, Tversion, Version, RJETSTREAMERROR,
         RVERSION, TVERSION,
     };
     pub use jetstream_wireformat::{Data, WireFormat};


### PR DESCRIPTION
Fifth in the subscriptions stack, on top of #697. This is the layer between the frames `RpcStream` yields and the items a caller declared — and the first example that actually runs.

```console
cargo run --example chat_room
```
```text
joined room-42
producers alive: 3
posted #1
  heard: ada says is anyone there?
  heard: ada says is anyone there?
producers alive after one left: 2
  ada heard: grace says here
  grace heard: grace says here
  ada's subscription closed at #2
  grace's subscription closed at #2
producers alive at the end: 0
```

Three lines of that output are three rules. `posted #1` arrives while all three subscriptions are open — the dispatcher fix from #697. `producers alive after one left: 2` is a dropped subscription stopping the *work*, not just the delivery. `closed at #2` is a result carried out through a merge and still attributable to the subscriber that received it.

### What's in it

**`Item::Next(T)` / `Item::Done(D)`** — the end is a value in the sequence, not the absence of one. That is the only shape that satisfies both `subscription.surface.terminal-value` (a `Stream` ends with `None`, and a result has nowhere to go) and `subscription.surface.composition` (`select_all` drops a finished stream silently). `subscription::merge` labels each subscription so a merged consumer can still say which one ended.

**`Producer<T, D>`** offers cancellation all three ways the spec allows — a signal to await, a flag to test, and a send that fails once cancelled. There's a test for the loop that watches nothing and stops anyway, because that is the loop people write.

**`Terminator<D>`** is the wire piece a typed ending needs, and it comes from a contradiction the earlier work didn't reach. `RDONE` is one global message id — that's what keeps `102 + 2 * index` intact for every other method. A protocol with *two* subscription methods then has two terminal types under that one id, and a decoder handed only the type byte cannot tell them apart, because decoding a body never sees the tag. So the payload names its method: one byte, and the two rules stop contradicting each other. Spec rule `subscription.termination.discriminant` on #694 (`de00ad7`-ish, pushed with the others).

### One more break, found the same way

The example is built against the crate rather than inside the workspace's `--all-features` run, and that turned up something the tests could not: `tokio::select!` needs tokio's `macros` feature, which this crate doesn't ask for. Everything passed under `--all-features` because the feature arrives transitively; plain `cargo build` was broken. Fixed on #697, since that's where `select!` was introduced.

### Verification

68 tests in `jetstream_rpc`, clippy clean on `--all-features --all-targets`, `cargo build -p jetstream_rpc` with default features, and the example runs. `docs/subscriptions.md` is a new book page that `{{#include}}`s the example; the book builds (its only errors are the pre-existing `jetstream_radar` includes on another page).

Still local Linux only — this branch doesn't target `main`, so only the benchmark job runs.

### Not in it

`#[service]` cannot generate any of the chat room's protocol yet. The example is hand-written for exactly that reason, and it is the specification of what the macro has to emit: `#[subscription]` on a method, a `Done` variant at `RDONE` carrying `Terminator<D>`, the three `Server` hooks, `Protocol::tcancel`, and a channel constructed over a session with an endpoint. That's the next one.

---
_Generated by [Claude Code](https://claude.ai/code/session_017u7J4fStrsu5W6CoXSw11t)_