### PR TITLE
feat(macros): `#[subscription]`, and a chat room the macro writes

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -103,5 +103,7 @@ jobs:
         run: cargo run --example iroh_echo --features iroh
       - name: Run example session_lanes
         run: cargo run --example session_lanes
+      - name: Run example chat_room
+        run: cargo run --example chat_room
       - name: Run example quic_session
         run: cargo run --example quic_session --features quic

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -63,6 +63,10 @@ jobs:
         run: |
           cargo build -p jetstream --verbose
           cargo test -p jetstream --verbose --all-features
+          # The generator's own tests. Not covered by `-p jetstream`, and
+          # that gap hid `jetstream_macros` failing to compile at all —
+          # 42 tests that never ran and 9 snapshots nothing checked.
+          cargo test -p jetstream_macros --verbose
 
   # Examples on stable only
   examples:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2927,7 +2927,7 @@ dependencies = [
  "jetstream_codegen",
  "lazy_static",
  "pretty_assertions",
- "prettyplease 0.3.0",
+ "prettyplease",
  "proc-macro2",
  "quote",
  "sha256",
@@ -4403,16 +4403,6 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.118",
-]
-
-[[package]]
-name = "prettyplease"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bfe0f4c752e450fc2faf62654f1c134747922825d5b04ca717b8874f41a40c0"
-dependencies = [
- "proc-macro2",
- "syn 3.0.3",
 ]
 
 [[package]]
@@ -7121,7 +7111,7 @@ dependencies = [
  "anyhow",
  "heck",
  "indexmap",
- "prettyplease 0.2.37",
+ "prettyplease",
  "syn 2.0.118",
  "wasm-metadata",
  "wit-bindgen-core",
@@ -7135,7 +7125,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
 dependencies = [
  "anyhow",
- "prettyplease 0.2.37",
+ "prettyplease",
  "proc-macro2",
  "quote",
  "syn 2.0.118",

--- a/components/jetstream_macros/Cargo.toml
+++ b/components/jetstream_macros/Cargo.toml
@@ -14,7 +14,7 @@ proc-macro2 = { version = "1.0.92", features = ["span-locations"] }
 convert_case = "0.11.0"
 sha256 = "1.5.0"
 lazy_static = "1.5.0"
-prettyplease = "0.3.0"
+prettyplease = "0.2.37"
 ident_case = "1.0.1"
 jetstream_codegen = { version = "16.2.0", path = "../jetstream_codegen" }
 

--- a/components/jetstream_macros/src/service/client.rs
+++ b/components/jetstream_macros/src/service/client.rs
@@ -1,19 +1,32 @@
+use std::collections::HashMap;
+
 use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{Attribute, Ident, TraitItem};
 
-use crate::utils::case_conversion::IdentCased;
+use crate::{
+    service::subscription::{done_struct_name, Streaming},
+    utils::case_conversion::IdentCased,
+};
 #[allow(clippy::too_many_arguments)]
 pub fn generate_client(
     channel_name: &Ident,
     trait_name: &Ident,
     trait_items: &[TraitItem],
     tmsgs: &[(Ident, TokenStream)],
+    rmsgs: &[(Ident, TokenStream)],
     method_attrs: &[Vec<Attribute>],
     enable_tracing: bool,
+    streaming: &HashMap<String, Streaming>,
 ) -> TokenStream {
-    let client_calls =
-        generate_client_calls(trait_items, tmsgs, method_attrs, enable_tracing);
+    let client_calls = generate_client_calls(
+        trait_items,
+        tmsgs,
+        rmsgs,
+        method_attrs,
+        enable_tracing,
+        streaming,
+    );
 
     // Add RPC-level tracing span if tracing is enabled
     let _rpc_span = if enable_tracing {
@@ -29,14 +42,38 @@ pub fn generate_client(
         quote! {}
     };
 
+    // r[impl jetstream.subscription.cancel]
+    // The client's half of cancellation. Without it a dropped
+    // subscription marks its tag abandoned and tells the service
+    // nothing, so the producer runs on — which is the whole failure the
+    // cancellation rule exists to prevent, and it is silent.
+    let tcancel_impl = if streaming.is_empty() {
+        quote! {}
+    } else {
+        quote! {
+            fn tcancel(oldtag: u16, binding: u64) -> Option<Tmessage> {
+                Some(Tmessage::Cancel(
+                    jetstream::prelude::subscription::Tcancel {
+                        oldtag,
+                        binding,
+                    },
+                ))
+            }
+        }
+    };
+
     quote! {
         pub struct #channel_name {
-            mux: Mux<Self>,
+            // r[impl jetstream.subscription.surface.rust]
+            // Shared, because a subscription outlives the call that
+            // opened it: the stream reads through this multiplexer long
+            // after the borrow that produced it is gone.
+            mux: std::sync::Arc<Mux<Self>>,
         }
 
         impl #channel_name {
             pub fn new(max_concurrent_requests:u16,inner: Box<dyn ClientTransport<Self>>) -> Self {
-                Self { mux: Mux::new(max_concurrent_requests,inner) }
+                Self { mux: std::sync::Arc::new(Mux::new(max_concurrent_requests,inner)) }
             }
 
             // r[impl jetstream.version.framer.client-handshake]
@@ -70,6 +107,8 @@ pub fn generate_client(
             type Error = Error;
             const VERSION: &'static str = PROTOCOL_VERSION;
             const NAME: &'static str = PROTOCOL_NAME;
+
+            #tcancel_impl
         }
 
         impl #trait_name for #channel_name
@@ -82,8 +121,10 @@ pub fn generate_client(
 fn generate_client_calls(
     trait_items: &[TraitItem],
     tmsgs: &[(Ident, TokenStream)],
+    rmsgs: &[(Ident, TokenStream)],
     method_attrs: &[Vec<Attribute>],
     enable_tracing: bool,
+    streaming: &HashMap<String, Streaming>,
 ) -> Vec<TokenStream> {
     trait_items
         .iter()
@@ -162,6 +203,53 @@ fn generate_client_calls(
                 } else {
                     attrs.iter().map(|attr| quote! { #attr }).collect()
                 };
+
+                // r[impl jetstream.subscription.surface.rust]
+                // A subscription is a `Stream`, cancelled by dropping
+                // it. It opens on first poll, which is what lets the
+                // method be the plain `fn` the surface calls for while
+                // acquiring a tag and sending a request stay
+                // asynchronous.
+                if streaming.contains_key(&method_name.to_string()) {
+                    let return_struct_ident = &rmsgs[index].0;
+                    let done_ident = done_struct_name(return_struct_ident);
+                    let args: Vec<_> = args.collect();
+                    return Some(quote! {
+                        #(#tracing_attrs)*
+                        fn #method_name(#reciever, #(#inputs)*) #retn {
+                            let mux = self.mux.clone();
+                            let req = Tmessage::#variant_name(#request_struct_ident {
+                                #(#args)*
+                            });
+                            Subscription::opening(async move {
+                                let frames = mux
+                                    .rpc_stream(Context::default(), req, 64)
+                                    .await;
+                                Subscription::from_frames(frames, |frame| {
+                                    match frame.msg {
+                                        Rmessage::#variant_name(item) => {
+                                            Ok(Some(Item::Next(item.0)))
+                                        }
+                                        Rmessage::Done(Done::#variant_name(
+                                            #done_ident(value),
+                                        )) => Ok(Some(Item::Done(value))),
+                                        // Cut short: the tag is freed and
+                                        // the sequence ends, carrying no
+                                        // result because the producer
+                                        // never produced one.
+                                        Rmessage::Done(Done::Cancelled) => {
+                                            Ok(None)
+                                        }
+                                        Rmessage::Error(err) => Err(err),
+                                        _ => Err(Error::new(
+                                            "unexpected response in a subscription",
+                                        )),
+                                    }
+                                })
+                            })
+                        }
+                    });
+                }
 
                 // r[impl jetstream.macro.client-error]
                 Some(quote! {

--- a/components/jetstream_macros/src/service/frame.rs
+++ b/components/jetstream_macros/src/service/frame.rs
@@ -4,7 +4,10 @@ use syn::Ident;
 
 use crate::utils::case_conversion::IdentCased;
 
-pub fn generate_tframe(tmsgs: &[(Ident, TokenStream)]) -> TokenStream {
+pub fn generate_tframe(
+    tmsgs: &[(Ident, TokenStream)],
+    has_subscriptions: bool,
+) -> TokenStream {
     let enum_name = quote! { Tmessage };
 
     let msg_variants = tmsgs.iter().map(|(ident, _p)| {
@@ -78,12 +81,39 @@ pub fn generate_tframe(tmsgs: &[(Ident, TokenStream)]) -> TokenStream {
         TVERSION => Ok(#enum_name::Version(WireFormat::decode(reader)?)),
     };
 
+    // r[impl jetstream.subscription.dispatch.declared]
+    // Cancellation is an ordinary request under a fresh tag, naming its
+    // target in the payload. A protocol with no subscriptions has
+    // nothing to cancel and emits none of this.
+    let (
+        cancel_variant,
+        cancel_byte_size,
+        cancel_message_type,
+        cancel_encode,
+        cancel_decode,
+    ) = if has_subscriptions {
+        (
+            quote! {
+                Cancel(jetstream::prelude::subscription::Tcancel) = TCANCEL,
+            },
+            quote! { #enum_name::Cancel(c) => c.byte_size(), },
+            quote! { #enum_name::Cancel(_) => TCANCEL, },
+            quote! { #enum_name::Cancel(c) => c.encode(writer)?, },
+            quote! {
+                TCANCEL => Ok(#enum_name::Cancel(WireFormat::decode(reader)?)),
+            },
+        )
+    } else {
+        (quote! {}, quote! {}, quote! {}, quote! {}, quote! {})
+    };
+
     quote! {
         #[derive(Debug)]
         #[repr(u8)]
         pub enum #enum_name {
             #( #msg_variants )*
             #version_variant
+            #cancel_variant
         }
 
         impl Framer for #enum_name {
@@ -93,6 +123,7 @@ pub fn generate_tframe(tmsgs: &[(Ident, TokenStream)]) -> TokenStream {
                         #cloned_byte_sizes,
                      )*
                     #version_byte_size,
+                    #cancel_byte_size
                 }
             }
 
@@ -102,6 +133,7 @@ pub fn generate_tframe(tmsgs: &[(Ident, TokenStream)]) -> TokenStream {
                         #message_type_match_arms,
                      )*
                     #version_message_type,
+                    #cancel_message_type
                 }
             }
 
@@ -111,6 +143,7 @@ pub fn generate_tframe(tmsgs: &[(Ident, TokenStream)]) -> TokenStream {
                         #encode_match_arms
                      )*
                     #version_encode
+                    #cancel_encode
                 }
                 Ok(())
             }
@@ -121,6 +154,7 @@ pub fn generate_tframe(tmsgs: &[(Ident, TokenStream)]) -> TokenStream {
                         #decode_bodies
                      )*
                     #version_decode
+                    #cancel_decode
                     _ => Err(std::io::Error::new(
                         std::io::ErrorKind::InvalidData,
                         format!("unknown message type: {}", ty),
@@ -131,7 +165,10 @@ pub fn generate_tframe(tmsgs: &[(Ident, TokenStream)]) -> TokenStream {
     }
 }
 
-pub fn generate_rframe(rmsgs: &[(Ident, TokenStream)]) -> TokenStream {
+pub fn generate_rframe(
+    rmsgs: &[(Ident, TokenStream)],
+    has_subscriptions: bool,
+) -> TokenStream {
     let enum_name = quote! { Rmessage };
 
     // Generate regular message variants
@@ -241,6 +278,43 @@ pub fn generate_rframe(rmsgs: &[(Ident, TokenStream)]) -> TokenStream {
         #enum_name::Version(_) => RVERSION
     };
 
+    // r[impl jetstream.subscription.termination]
+    // r[impl jetstream.subscription.cancel]
+    // The terminator and the acknowledgement, both on global ids so a
+    // streaming method costs no per-method id.
+    let (
+        stream_variants,
+        stream_byte_size,
+        stream_message_type,
+        stream_encode,
+        stream_decode,
+    ) = if has_subscriptions {
+        (
+            quote! {
+                Done(Done) = RDONE,
+                CancelAck(jetstream::prelude::subscription::Rcancel) = RCANCEL,
+            },
+            quote! {
+                #enum_name::Done(d) => d.byte_size(),
+                #enum_name::CancelAck(a) => a.byte_size(),
+            },
+            quote! {
+                #enum_name::Done(_) => RDONE,
+                #enum_name::CancelAck(_) => RCANCEL,
+            },
+            quote! {
+                #enum_name::Done(d) => d.encode(writer)?,
+                #enum_name::CancelAck(a) => a.encode(writer)?,
+            },
+            quote! {
+                RDONE => Ok(#enum_name::Done(WireFormat::decode(reader)?)),
+                RCANCEL => Ok(#enum_name::CancelAck(WireFormat::decode(reader)?)),
+            },
+        )
+    } else {
+        (quote! {}, quote! {}, quote! {}, quote! {}, quote! {})
+    };
+
     quote! {
         #[derive(Debug)]
         #[repr(u8)]
@@ -248,6 +322,7 @@ pub fn generate_rframe(rmsgs: &[(Ident, TokenStream)]) -> TokenStream {
             #( #msg_variants )*
             #error_variant
             #rversion_variant
+            #stream_variants
         }
 
         impl Framer for #enum_name {
@@ -259,6 +334,7 @@ pub fn generate_rframe(rmsgs: &[(Ident, TokenStream)]) -> TokenStream {
                      )*
                     #error_byte_size,
                     #rversion_byte_size,
+                    #stream_byte_size
                 }
             }
 
@@ -269,6 +345,7 @@ pub fn generate_rframe(rmsgs: &[(Ident, TokenStream)]) -> TokenStream {
                      )*
                     #error_message_type,
                     #rversion_message_type,
+                    #stream_message_type
                 }
             }
 
@@ -279,6 +356,7 @@ pub fn generate_rframe(rmsgs: &[(Ident, TokenStream)]) -> TokenStream {
                      )*
                     #error_encode
                     #rversion_encode
+                    #stream_encode
                 }
                 Ok(())
             }
@@ -290,6 +368,7 @@ pub fn generate_rframe(rmsgs: &[(Ident, TokenStream)]) -> TokenStream {
                      )*
                     #error_decode
                     #rversion_decode
+                    #stream_decode
                     _ => Err(std::io::Error::new(
                         std::io::ErrorKind::InvalidData,
                         format!("unknown message type: {}", ty),

--- a/components/jetstream_macros/src/service/mod.rs
+++ b/components/jetstream_macros/src/service/mod.rs
@@ -2,14 +2,14 @@ mod client;
 mod frame;
 mod message;
 mod server;
+pub(crate) mod subscription;
 mod tests;
 mod tests_tracing;
 mod tracing;
 
 use proc_macro2::{Literal, TokenStream};
 use quote::{format_ident, quote, ToTokens};
-
-use syn::{ItemTrait, TraitItem};
+use syn::{Ident, ItemTrait, TraitItem};
 
 use crate::service::tracing::take_attributes;
 
@@ -85,7 +85,27 @@ pub(crate) fn service_impl(item: ItemTrait, attr: ServiceAttr) -> TokenStream {
             .collect::<Vec<_>>()
             .as_slice(),
     );
-    let trait_items = maps.iter().map(|(item, _)| item).collect::<Vec<_>>();
+    // r[impl jetstream.subscription.surface.declared]
+    // `#[subscription]` is this macro's own attribute, so it has to come
+    // off before the trait is emitted — and what it says has to be kept,
+    // because the dispatcher routes on it.
+    let mut streaming: std::collections::HashMap<
+        String,
+        subscription::Streaming,
+    > = std::collections::HashMap::new();
+    let mut trait_fns = Vec::new();
+    for (item, _) in maps.iter() {
+        let mut item = item.clone();
+        match subscription::take(&mut item) {
+            Ok(Some(s)) => {
+                streaming.insert(item.sig.ident.to_string(), s);
+            }
+            Ok(None) => {}
+            Err(e) => return e.to_compile_error(),
+        }
+        trait_fns.push(item);
+    }
+    let trait_items = trait_fns.iter().collect::<Vec<_>>();
     let vis = &item.vis;
 
     // Generate protocol metadata
@@ -100,6 +120,8 @@ pub(crate) fn service_impl(item: ItemTrait, attr: ServiceAttr) -> TokenStream {
     let mut rmsgs = Vec::new();
     let mut msg_ids = Vec::new();
     let mut method_attrs = Vec::new();
+    let mut done_structs = Vec::new();
+    let mut done_variants = Vec::new();
 
     for (index, item) in item.items.iter().enumerate() {
         if let TraitItem::Fn(method) = item {
@@ -116,10 +138,46 @@ pub(crate) fn service_impl(item: ItemTrait, attr: ServiceAttr) -> TokenStream {
                 &request_struct_ident,
                 &method.sig,
             );
-            let return_struct = message::generate_return_struct(
-                &return_struct_ident,
-                &method.sig,
-            );
+
+            let stream = streaming.get(&method_name.to_string());
+            let return_struct = match stream {
+                // A subscription's response struct carries one *item*,
+                // not the whole return type: the sequence is many of
+                // these, and the end is a value of its own.
+                Some(s) => {
+                    let item = &s.item;
+                    quote! {
+                        #[allow(non_camel_case_types)]
+                        #[derive(Debug, JetStreamWireFormat)]
+                        pub struct #return_struct_ident(pub #item);
+                    }
+                }
+                None => message::generate_return_struct(
+                    &return_struct_ident,
+                    &method.sig,
+                ),
+            };
+
+            if let Some(s) = stream {
+                let done_ident =
+                    subscription::done_struct_name(&return_struct_ident);
+                let done_ty = &s.done;
+                done_structs.push(quote! {
+                    #[allow(non_camel_case_types)]
+                    #[derive(Debug, JetStreamWireFormat)]
+                    pub struct #done_ident(pub #done_ty);
+                });
+                let variant: Ident = crate::utils::case_conversion::IdentCased(
+                    method_name.clone(),
+                )
+                .to_pascal_case()
+                .into();
+                let request_id = Ident::new(
+                    &format!("T{}", method_name.to_string().to_uppercase()),
+                    method_name.span(),
+                );
+                done_variants.push((variant, done_ident, request_id));
+            }
 
             tmsgs.push((request_struct_ident, request_struct));
             rmsgs.push((return_struct_ident, return_struct));
@@ -131,8 +189,29 @@ pub(crate) fn service_impl(item: ItemTrait, attr: ServiceAttr) -> TokenStream {
     }
 
     // Generate frame implementations
-    let tmessage = frame::generate_tframe(&tmsgs);
-    let rmessage = frame::generate_rframe(&rmsgs);
+    let has_subscriptions = !done_variants.is_empty();
+    let tmessage = frame::generate_tframe(&tmsgs, has_subscriptions);
+    let rmessage = frame::generate_rframe(&rmsgs, has_subscriptions);
+    let stream_consts = if has_subscriptions {
+        quote! {
+            /// r[impl jetstream.subscription.compat]
+            /// The terminator and cancellation take global ids below
+            /// `MESSAGE_ID_START`, so a streaming method costs no
+            /// per-method id and `102 + 2 * index` is untouched.
+            pub const RDONE: u8 = jetstream::prelude::subscription::RDONE;
+            pub const TCANCEL: u8 = jetstream::prelude::subscription::TCANCEL;
+            pub const RCANCEL: u8 = jetstream::prelude::subscription::RCANCEL;
+        }
+    } else {
+        quote! {}
+    };
+    let done_enum = if has_subscriptions {
+        subscription::generate_done_enum(&done_variants)
+    } else {
+        // A protocol with no subscriptions emits exactly what it did
+        // before this existed — r[jetstream.subscription.compat.rpc-layer].
+        quote! {}
+    };
 
     // Generate server implementation
     let server_impl = server::generate_server(
@@ -143,6 +222,7 @@ pub(crate) fn service_impl(item: ItemTrait, attr: ServiceAttr) -> TokenStream {
         &rmsgs,
         &method_attrs,
         enable_tracing,
+        &streaming,
     );
 
     // Generate client implementation
@@ -151,8 +231,10 @@ pub(crate) fn service_impl(item: ItemTrait, attr: ServiceAttr) -> TokenStream {
         trait_name,
         &item.items,
         &tmsgs,
+        &rmsgs,
         &method_attrs,
         enable_tracing,
+        &streaming,
     );
 
     // Generate final trait with attribute
@@ -210,11 +292,17 @@ pub(crate) fn service_impl(item: ItemTrait, attr: ServiceAttr) -> TokenStream {
             );
             const DIGEST: &str = #digest_lit;
 
+            #stream_consts
+
             #(#msg_ids)*
 
             #(#tmsg_definitions)*
 
             #(#rmsg_definitions)*
+
+            #(#done_structs)*
+
+            #done_enum
 
             #tmessage
 

--- a/components/jetstream_macros/src/service/server.rs
+++ b/components/jetstream_macros/src/service/server.rs
@@ -369,7 +369,22 @@ fn generate_streaming(
                                 #done_ident(value),
                             )),
                         }),
-                        Err(err) => Err(err),
+                        // r[impl jetstream.subscription.surface.termination]
+                        // A producer failure ends *this* subscription,
+                        // not the lane. Returning `Err` here made the
+                        // item a transport error, which `server::run`
+                        // propagates — so one failing room tore down
+                        // every other subscription and every unary call
+                        // sharing the lane, and the caller never reached
+                        // the error arm its generated client has. As an
+                        // error frame under this tag it is the failure
+                        // the surface has to distinguish from a normal
+                        // end, delivered to the one subscriber it
+                        // concerns.
+                        Err(err) => Ok(Frame {
+                            tag,
+                            msg: Rmessage::Error(err),
+                        }),
                     },
                 )) as jetstream::prelude::server::ResponseStream<Self>
             }

--- a/components/jetstream_macros/src/service/server.rs
+++ b/components/jetstream_macros/src/service/server.rs
@@ -1,8 +1,13 @@
+use std::collections::HashMap;
+
 use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{Attribute, Ident, TraitItem};
 
-use crate::utils::case_conversion::IdentCased;
+use crate::{
+    service::subscription::{done_struct_name, Streaming},
+    utils::case_conversion::IdentCased,
+};
 
 #[allow(clippy::too_many_arguments)]
 pub fn generate_server(
@@ -13,6 +18,7 @@ pub fn generate_server(
     rmsgs: &[(Ident, TokenStream)],
     method_attrs: &[Vec<Attribute>],
     enable_tracing: bool,
+    streaming: &HashMap<String, Streaming>,
 ) -> TokenStream {
     let match_arms = generate_match_arms(
         tmsgs.iter().map(|(id, ts)| (id.clone(), ts.clone())),
@@ -26,6 +32,22 @@ pub fn generate_server(
                 let name: IdentCased = method_name.into();
                 let variant_name: Ident = name.to_pascal_case().into();
                 let return_struct_ident = &rmsgs[index].0;
+
+                // r[impl jetstream.subscription.surface.declared]
+                // A streaming method is not answerable with one frame,
+                // and the dispatcher routes it to `rpc_stream` before it
+                // gets here. This arm exists only so the match is
+                // exhaustive; reaching it means the routing is wrong.
+                if streaming.contains_key(&method_name.to_string()) {
+                    return Some(quote! {
+                        {
+                            let _ = msg;
+                            Err(Error::new(
+                                "a subscription cannot be answered with one frame",
+                            ))
+                        }
+                    });
+                }
 
                 // Get the method parameters (excluding self and Context)
                 // Context is passed separately via _ctx parameter
@@ -68,6 +90,20 @@ pub fn generate_server(
     let matches = std::iter::zip(match_arms, match_arm_bodies.iter())
         .map(|(arm, body)| quote! { #arm => #body });
 
+    // r[impl jetstream.subscription.cancel]
+    // The dispatcher takes cancellations before they reach here, so this
+    // arm exists to make the match exhaustive. Reaching it means a
+    // cancellation was routed as an ordinary call.
+    let cancel_match_arm = if streaming.is_empty() {
+        quote! {}
+    } else {
+        quote! {
+            Tmessage::Cancel(_) => Err(Error::new(
+                "a cancellation is not a unary call",
+            )),
+        }
+    };
+
     // r[impl jetstream.version.framer.server-dispatch]
     // Version negotiation match arm — handles Tversion before service methods
     let version_match_arm = quote! {
@@ -103,8 +139,30 @@ pub fn generate_server(
     };
 
     // Generate trait implementation methods
-    let trait_methods =
-        generate_trait_methods(trait_items, method_attrs, enable_tracing);
+    let trait_methods = generate_trait_methods(
+        trait_items,
+        method_attrs,
+        enable_tracing,
+        streaming,
+    );
+
+    let streaming_impl =
+        generate_streaming(trait_items, tmsgs, rmsgs, streaming);
+    let tcancel_impl = if streaming.is_empty() {
+        quote! {}
+    } else {
+        // r[impl jetstream.subscription.cancel]
+        quote! {
+            fn tcancel(oldtag: u16, binding: u64) -> Option<Tmessage> {
+                Some(Tmessage::Cancel(
+                    jetstream::prelude::subscription::Tcancel {
+                        oldtag,
+                        binding,
+                    },
+                ))
+            }
+        }
+    };
 
     quote! {
         #[derive(Clone, Debug)]
@@ -122,6 +180,8 @@ pub fn generate_server(
             type Error = Error;
             const VERSION: &'static str = PROTOCOL_VERSION;
             const NAME: &'static str = PROTOCOL_NAME;
+
+            #tcancel_impl
         }
 
         impl<T> Server for #service_name<T>
@@ -136,6 +196,7 @@ pub fn generate_server(
                     let req: <Self as Protocol>::Request = frame.msg;
                     let res: std::result::Result<<Self as Protocol>::Response, Self::Error> = match req {
                         #version_match_arm
+                        #cancel_match_arm
                         #(#matches)*
                     };
                     // r[impl jetstream.macro.server-error]
@@ -148,6 +209,8 @@ pub fn generate_server(
                     Ok(rframe)
                 })
             }
+
+            #streaming_impl
         }
 
         impl<T> #trait_name for #service_name<T>
@@ -173,6 +236,7 @@ fn generate_trait_methods(
     trait_items: &[TraitItem],
     method_attrs: &[Vec<Attribute>],
     enable_tracing: bool,
+    streaming: &HashMap<String, Streaming>,
 ) -> Vec<TokenStream> {
     trait_items
         .iter()
@@ -202,10 +266,19 @@ fn generate_trait_methods(
                         attrs.iter().map(|attr| quote! { #attr }).collect()
                     };
 
+                // A subscription method is not `async`: it hands back a
+                // stream, which is where the waiting happens.
+                let maybe_await =
+                    if streaming.contains_key(&method_name.to_string()) {
+                        quote! {}
+                    } else {
+                        quote! { .await }
+                    };
+
                 Some(quote! {
                     #(#tracing_attrs)*
                     #method_sig {
-                        self.inner.#method_name(#(#params),*).await
+                        self.inner.#method_name(#(#params),*) #maybe_await
                     }
                 })
             } else {
@@ -213,4 +286,141 @@ fn generate_trait_methods(
             }
         })
         .collect()
+}
+
+/// r[impl jetstream.subscription.dispatch.declared]
+/// Everything the dispatcher needs from a protocol that has
+/// subscriptions: what streams, what cancels, what answers a
+/// cancellation, what terminates one cut short, and how to serve one.
+///
+/// A protocol with none emits nothing here, so the defaults stand and it
+/// compiles exactly as it did — r[jetstream.subscription.compat.rpc-layer].
+fn generate_streaming(
+    trait_items: &[TraitItem],
+    tmsgs: &[(Ident, TokenStream)],
+    rmsgs: &[(Ident, TokenStream)],
+    streaming: &HashMap<String, Streaming>,
+) -> TokenStream {
+    if streaming.is_empty() {
+        return quote! {};
+    }
+
+    let mut request_ids = Vec::new();
+    let mut serve_arms = Vec::new();
+
+    for (index, item) in trait_items.iter().enumerate() {
+        let TraitItem::Fn(method) = item else {
+            continue;
+        };
+        let method_name = &method.sig.ident;
+        if !streaming.contains_key(&method_name.to_string()) {
+            continue;
+        }
+        let name: IdentCased = method_name.into();
+        let variant_name: Ident = name.to_pascal_case().into();
+        let request_id = Ident::new(
+            &format!("T{}", method_name.to_string().to_uppercase()),
+            method_name.span(),
+        );
+        request_ids.push(request_id);
+
+        let return_struct_ident = &rmsgs[index].0;
+        let done_ident = done_struct_name(return_struct_ident);
+        let _ = &tmsgs[index];
+
+        // The arguments the trait method takes, read out of the request
+        // struct — with `ctx` passed through as it is for a unary call.
+        let params = method.sig.inputs.iter().filter_map(|arg| match arg {
+            syn::FnArg::Typed(pat) => {
+                let name = pat.pat.clone();
+                if let syn::Type::Path(type_path) = &*pat.ty {
+                    if let Some(segment) = type_path.path.segments.last() {
+                        if segment.ident == "Context" {
+                            return Some(quote! { ctx });
+                        }
+                    }
+                }
+                Some(quote! { msg.#name })
+            }
+            syn::FnArg::Receiver(_) => None,
+        });
+
+        serve_arms.push(quote! {
+            Tmessage::#variant_name(msg) => {
+                // r[impl jetstream.subscription.cancel]
+                // Serving is where the producer is handed the token
+                // that says its subscriber has gone.
+                let items = self
+                    .inner
+                    .#method_name(#(#params),*)
+                    .serve(cancel);
+                Box::pin(jetstream::prelude::futures::StreamExt::map(
+                    items,
+                    move |item| match item {
+                        Ok(Item::Next(value)) => Ok(Frame {
+                            tag,
+                            msg: Rmessage::#variant_name(
+                                #return_struct_ident(value),
+                            ),
+                        }),
+                        Ok(Item::Done(value)) => Ok(Frame {
+                            tag,
+                            msg: Rmessage::Done(Done::#variant_name(
+                                #done_ident(value),
+                            )),
+                        }),
+                        Err(err) => Err(err),
+                    },
+                )) as jetstream::prelude::server::ResponseStream<Self>
+            }
+        });
+    }
+
+    quote! {
+        // r[impl jetstream.subscription.surface.declared]
+        fn is_streaming(message_type: u8) -> bool {
+            matches!(message_type, #(#request_ids)|*)
+        }
+
+        // r[impl jetstream.subscription.cancel]
+        fn cancel_target(frame: &Frame<Tmessage>) -> Option<u16> {
+            match &frame.msg {
+                Tmessage::Cancel(cancel) => Some(cancel.oldtag),
+                _ => None,
+            }
+        }
+
+        // r[impl jetstream.subscription.cancel]
+        fn cancel_ack(oldtag: u16) -> Option<Rmessage> {
+            Some(Rmessage::CancelAck(
+                jetstream::prelude::subscription::Rcancel { oldtag },
+            ))
+        }
+
+        // r[impl jetstream.subscription.dispatch.terminator]
+        // No result, because a producer stopped by cancellation never
+        // produced one. Its job is to free the tag.
+        fn cancelled_terminator(_method: u8) -> Option<Rmessage> {
+            Some(Rmessage::Done(Done::Cancelled))
+        }
+
+        fn rpc_stream(
+            &mut self,
+            ctx: Context,
+            frame: Frame<<Self as Protocol>::Request>,
+            cancel: jetstream::prelude::subscription::CancellationToken,
+        ) -> impl ::core::future::Future<
+            Output = jetstream::prelude::server::ResponseStream<Self>,
+        > + Send + Sync {
+            Box::pin(async move {
+                let tag = frame.tag;
+                match frame.msg {
+                    #(#serve_arms)*
+                    _ => Box::pin(
+                        jetstream::prelude::futures::stream::empty(),
+                    ) as jetstream::prelude::server::ResponseStream<Self>,
+                }
+            })
+        }
+    }
 }

--- a/components/jetstream_macros/src/service/server.rs
+++ b/components/jetstream_macros/src/service/server.rs
@@ -350,41 +350,61 @@ fn generate_streaming(
                 // r[impl jetstream.subscription.cancel]
                 // Serving is where the producer is handed the token
                 // that says its subscriber has gone.
+                // Through the generated wrapper, not `self.inner`: that
+                // is where `#[tracing::instrument]` is installed, and a
+                // unary call reaches it as `self.#method_name`. Calling
+                // the inner trait directly here made subscription spans
+                // the only ones that silently went missing.
                 let items = self
-                    .inner
                     .#method_name(#(#params),*)
                     .serve(cancel);
-                Box::pin(jetstream::prelude::futures::StreamExt::map(
-                    items,
-                    move |item| match item {
-                        Ok(Item::Next(value)) => Ok(Frame {
-                            tag,
-                            msg: Rmessage::#variant_name(
-                                #return_struct_ident(value),
+                // A terminal item ends the response stream, rather than
+                // being mapped and left to the source to stop on its
+                // own. The dispatcher frees the tag on `Out::Ended` and
+                // nowhere else, so a source that yields `Err` (or its
+                // terminator) and then hangs would hold the tag open for
+                // the life of the connection and never produce the
+                // synthetic terminator that releases the caller. Ending
+                // here also means nothing can be delivered *after* an
+                // ending, which is the guarantee the surface makes.
+                Box::pin(jetstream::prelude::futures::stream::unfold(
+                    (items, false),
+                    move |(mut items, finished)| async move {
+                        use jetstream::prelude::futures::StreamExt as _;
+                        if finished {
+                            return None;
+                        }
+                        let (msg, finished) = match items.next().await? {
+                            Ok(Item::Next(value)) => (
+                                Rmessage::#variant_name(
+                                    #return_struct_ident(value),
+                                ),
+                                false,
                             ),
-                        }),
-                        Ok(Item::Done(value)) => Ok(Frame {
-                            tag,
-                            msg: Rmessage::Done(Done::#variant_name(
-                                #done_ident(value),
-                            )),
-                        }),
-                        // r[impl jetstream.subscription.surface.termination]
-                        // A producer failure ends *this* subscription,
-                        // not the lane. Returning `Err` here made the
-                        // item a transport error, which `server::run`
-                        // propagates — so one failing room tore down
-                        // every other subscription and every unary call
-                        // sharing the lane, and the caller never reached
-                        // the error arm its generated client has. As an
-                        // error frame under this tag it is the failure
-                        // the surface has to distinguish from a normal
-                        // end, delivered to the one subscriber it
-                        // concerns.
-                        Err(err) => Ok(Frame {
-                            tag,
-                            msg: Rmessage::Error(err),
-                        }),
+                            Ok(Item::Done(value)) => (
+                                Rmessage::Done(Done::#variant_name(
+                                    #done_ident(value),
+                                )),
+                                true,
+                            ),
+                            // r[impl jetstream.subscription.surface.termination]
+                            // A producer failure ends *this* subscription,
+                            // not the lane. Returning `Err` here made the
+                            // item a transport error, which `server::run`
+                            // propagates — so one failing room tore down
+                            // every other subscription and every unary call
+                            // sharing the lane, and the caller never reached
+                            // the error arm its generated client has. As an
+                            // error frame under this tag it is the failure
+                            // the surface has to distinguish from a normal
+                            // end, delivered to the one subscriber it
+                            // concerns.
+                            Err(err) => (Rmessage::Error(err), true),
+                        };
+                        Some((
+                            Ok(Frame { tag, msg }),
+                            (items, finished),
+                        ))
                     },
                 )) as jetstream::prelude::server::ResponseStream<Self>
             }

--- a/components/jetstream_macros/src/service/snapshots/jetstream_macros__service__tests__async_trait_service_with_args.snap
+++ b/components/jetstream_macros/src/service/snapshots/jetstream_macros__service__tests__async_trait_service_with_args.snap
@@ -212,7 +212,7 @@ pub mod echo_protocol {
         }
     }
     pub struct EchoChannel {
-        mux: Mux<Self>,
+        mux: std::sync::Arc<Mux<Self>>,
     }
     impl EchoChannel {
         pub fn new(
@@ -220,7 +220,7 @@ pub mod echo_protocol {
             inner: Box<dyn ClientTransport<Self>>,
         ) -> Self {
             Self {
-                mux: Mux::new(max_concurrent_requests, inner),
+                mux: std::sync::Arc::new(Mux::new(max_concurrent_requests, inner)),
             }
         }
         /// Perform Tversion/Rversion handshake with the server.

--- a/components/jetstream_macros/src/service/snapshots/jetstream_macros__service__tests__service_with_args.snap
+++ b/components/jetstream_macros/src/service/snapshots/jetstream_macros__service__tests__service_with_args.snap
@@ -212,7 +212,7 @@ pub mod echo_protocol {
         }
     }
     pub struct EchoChannel {
-        mux: Mux<Self>,
+        mux: std::sync::Arc<Mux<Self>>,
     }
     impl EchoChannel {
         pub fn new(
@@ -220,7 +220,7 @@ pub mod echo_protocol {
             inner: Box<dyn ClientTransport<Self>>,
         ) -> Self {
             Self {
-                mux: Mux::new(max_concurrent_requests, inner),
+                mux: std::sync::Arc::new(Mux::new(max_concurrent_requests, inner)),
             }
         }
         /// Perform Tversion/Rversion handshake with the server.

--- a/components/jetstream_macros/src/service/snapshots/jetstream_macros__service__tests__service_with_subscription.snap
+++ b/components/jetstream_macros/src/service/snapshots/jetstream_macros__service__tests__service_with_subscription.snap
@@ -346,29 +346,25 @@ pub mod room_protocol {
                 let tag = frame.tag;
                 match frame.msg {
                     Tmessage::Events(msg) => {
-                        let items = self.inner.events(msg.from).serve(cancel);
+                        let items = self.events(msg.from).serve(cancel);
                         Box::pin(
-                            jetstream::prelude::futures::StreamExt::map(
-                                items,
-                                move |item| match item {
-                                    Ok(Item::Next(value)) => {
-                                        Ok(Frame {
-                                            tag,
-                                            msg: Rmessage::Events(Revents(value)),
-                                        })
+                            jetstream::prelude::futures::stream::unfold(
+                                (items, false),
+                                move |(mut items, finished)| async move {
+                                    use jetstream::prelude::futures::StreamExt as _;
+                                    if finished {
+                                        return None;
                                     }
-                                    Ok(Item::Done(value)) => {
-                                        Ok(Frame {
-                                            tag,
-                                            msg: Rmessage::Done(Done::Events(ReventsDone(value))),
-                                        })
-                                    }
-                                    Err(err) => {
-                                        Ok(Frame {
-                                            tag,
-                                            msg: Rmessage::Error(err),
-                                        })
-                                    }
+                                    let (msg, finished) = match items.next().await? {
+                                        Ok(Item::Next(value)) => {
+                                            (Rmessage::Events(Revents(value)), false)
+                                        }
+                                        Ok(Item::Done(value)) => {
+                                            (Rmessage::Done(Done::Events(ReventsDone(value))), true)
+                                        }
+                                        Err(err) => (Rmessage::Error(err), true),
+                                    };
+                                    Some((Ok(Frame { tag, msg }), (items, finished)))
                                 },
                             ),
                         ) as jetstream::prelude::server::ResponseStream<Self>

--- a/components/jetstream_macros/src/service/snapshots/jetstream_macros__service__tests__service_with_subscription.snap
+++ b/components/jetstream_macros/src/service/snapshots/jetstream_macros__service__tests__service_with_subscription.snap
@@ -1,0 +1,481 @@
+---
+source: components/jetstream_macros/src/service/tests.rs
+expression: output_str
+---
+pub mod room_protocol {
+    use jetstream::prelude::*;
+    use std::mem;
+    use super::Room;
+    const MESSAGE_ID_START: u8 = 102;
+    /// Error response message type constant
+    pub const RERROR: u8 = jetstream::prelude::RJETSTREAMERROR;
+    /// Version request message type constant
+    pub const TVERSION: u8 = jetstream::prelude::TVERSION;
+    /// Version response message type constant
+    pub const RVERSION: u8 = jetstream::prelude::RVERSION;
+    /// Protocol name — used for routing
+    pub const PROTOCOL_NAME: &str = "room";
+    /// Protocol version string constructed from the generated crate's version
+    pub const PROTOCOL_VERSION: &str = concat!(
+        "rs.jetstream.proto/", "room", "/", env!("CARGO_PKG_VERSION_MAJOR"), ".",
+        env!("CARGO_PKG_VERSION_MINOR"), ".", env!("CARGO_PKG_VERSION_PATCH"), "+",
+        "6a26a299"
+    );
+    const DIGEST: &str = "DIGEST_HASH";
+    /// r[impl jetstream.subscription.compat]
+    /// The terminator and cancellation take global ids below
+    /// `MESSAGE_ID_START`, so a streaming method costs no
+    /// per-method id and `102 + 2 * index` is untouched.
+    pub const RDONE: u8 = jetstream::prelude::subscription::RDONE;
+    pub const TCANCEL: u8 = jetstream::prelude::subscription::TCANCEL;
+    pub const RCANCEL: u8 = jetstream::prelude::subscription::RCANCEL;
+    pub const TPOST: u8 = MESSAGE_ID_START + 0u8;
+    pub const RPOST: u8 = MESSAGE_ID_START + 0u8 + 1;
+    pub const TEVENTS: u8 = MESSAGE_ID_START + 2u8;
+    pub const REVENTS: u8 = MESSAGE_ID_START + 2u8 + 1;
+    #[allow(non_camel_case_types)]
+    #[derive(Debug, JetStreamWireFormat)]
+    pub struct Tpost {
+        pub body: String,
+    }
+    #[allow(non_camel_case_types)]
+    #[derive(Debug, JetStreamWireFormat)]
+    pub struct Tevents {
+        pub from: u64,
+    }
+    #[allow(non_camel_case_types)]
+    #[derive(Debug, JetStreamWireFormat)]
+    pub struct Rpost(pub u64);
+    #[allow(non_camel_case_types)]
+    #[derive(Debug, JetStreamWireFormat)]
+    pub struct Revents(pub Event);
+    #[allow(non_camel_case_types)]
+    #[derive(Debug, JetStreamWireFormat)]
+    pub struct ReventsDone(pub Closed);
+    /// r[impl jetstream.subscription.dispatch.terminator]
+    /// The end of a subscription, and what it ended with. The
+    /// payload names its method, because `RDONE` is one global id
+    /// and a decoder is handed the type byte alone.
+    #[derive(Debug)]
+    pub enum Done {
+        Events(ReventsDone),
+        /// r[impl jetstream.subscription.dispatch.terminator]
+        /// The subscription was cut short, so it carries no result:
+        /// a producer stopped by cancellation never produced one,
+        /// and a default value in its place would report a result
+        /// that did not happen. Its only job is to free the tag.
+        ///
+        /// Method id zero, which no method can have —
+        /// `MESSAGE_ID_START` is 102.
+        Cancelled,
+    }
+    impl WireFormat for Done {
+        fn byte_size(&self) -> u32 {
+            match self {
+                Done::Events(v) => 1 + v.byte_size(),
+                Done::Cancelled => 1,
+            }
+        }
+        fn encode<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
+            match self {
+                Done::Events(v) => {
+                    WireFormat::encode(&TEVENTS, writer)?;
+                    v.encode(writer)
+                }
+                Done::Cancelled => WireFormat::encode(&0u8, writer),
+            }
+        }
+        fn decode<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
+            let method: u8 = WireFormat::decode(reader)?;
+            match method {
+                0u8 => Ok(Done::Cancelled),
+                TEVENTS => Ok(Done::Events(WireFormat::decode(reader)?)),
+                other => {
+                    Err(
+                        std::io::Error::new(
+                            std::io::ErrorKind::InvalidData,
+                            format!("terminator for an unknown method: {}", other),
+                        ),
+                    )
+                }
+            }
+        }
+    }
+    #[derive(Debug)]
+    #[repr(u8)]
+    pub enum Tmessage {
+        Post(Tpost) = TPOST,
+        Events(Tevents) = TEVENTS,
+        Version(jetstream::prelude::Tversion) = TVERSION,
+        Cancel(jetstream::prelude::subscription::Tcancel) = TCANCEL,
+    }
+    impl Framer for Tmessage {
+        fn byte_size(&self) -> u32 {
+            match &self {
+                Tmessage::Post(msg) => msg.byte_size(),
+                Tmessage::Events(msg) => msg.byte_size(),
+                Tmessage::Version(v) => v.byte_size(),
+                Tmessage::Cancel(c) => c.byte_size(),
+            }
+        }
+        fn message_type(&self) -> u8 {
+            match self {
+                Tmessage::Post(_) => TPOST,
+                Tmessage::Events(_) => TEVENTS,
+                Tmessage::Version(_) => TVERSION,
+                Tmessage::Cancel(_) => TCANCEL,
+            }
+        }
+        fn encode<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
+            match &self {
+                Tmessage::Post(msg) => msg.encode(writer)?,
+                Tmessage::Events(msg) => msg.encode(writer)?,
+                Tmessage::Version(v) => v.encode(writer)?,
+                Tmessage::Cancel(c) => c.encode(writer)?,
+            }
+            Ok(())
+        }
+        fn decode<R: std::io::Read>(
+            reader: &mut R,
+            ty: u8,
+        ) -> std::io::Result<Tmessage> {
+            match ty {
+                TPOST => Ok(Tmessage::Post(WireFormat::decode(reader)?)),
+                TEVENTS => Ok(Tmessage::Events(WireFormat::decode(reader)?)),
+                TVERSION => Ok(Tmessage::Version(WireFormat::decode(reader)?)),
+                TCANCEL => Ok(Tmessage::Cancel(WireFormat::decode(reader)?)),
+                _ => {
+                    Err(
+                        std::io::Error::new(
+                            std::io::ErrorKind::InvalidData,
+                            format!("unknown message type: {}", ty),
+                        ),
+                    )
+                }
+            }
+        }
+    }
+    #[derive(Debug)]
+    #[repr(u8)]
+    pub enum Rmessage {
+        Post(Rpost) = RPOST,
+        Events(Revents) = REVENTS,
+        Error(jetstream::prelude::Error) = RERROR,
+        Version(jetstream::prelude::Rversion) = RVERSION,
+        Done(Done) = RDONE,
+        CancelAck(jetstream::prelude::subscription::Rcancel) = RCANCEL,
+    }
+    impl Framer for Rmessage {
+        fn byte_size(&self) -> u32 {
+            match &self {
+                Rmessage::Post(msg) => msg.byte_size(),
+                Rmessage::Events(msg) => msg.byte_size(),
+                Rmessage::Error(err) => err.byte_size(),
+                Rmessage::Version(v) => v.byte_size(),
+                Rmessage::Done(d) => d.byte_size(),
+                Rmessage::CancelAck(a) => a.byte_size(),
+            }
+        }
+        fn message_type(&self) -> u8 {
+            match self {
+                Rmessage::Post(_) => RPOST,
+                Rmessage::Events(_) => REVENTS,
+                Rmessage::Error(_) => RERROR,
+                Rmessage::Version(_) => RVERSION,
+                Rmessage::Done(_) => RDONE,
+                Rmessage::CancelAck(_) => RCANCEL,
+            }
+        }
+        fn encode<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
+            match &self {
+                Rmessage::Post(msg) => msg.encode(writer)?,
+                Rmessage::Events(msg) => msg.encode(writer)?,
+                Rmessage::Error(err) => err.encode(writer)?,
+                Rmessage::Version(v) => v.encode(writer)?,
+                Rmessage::Done(d) => d.encode(writer)?,
+                Rmessage::CancelAck(a) => a.encode(writer)?,
+            }
+            Ok(())
+        }
+        fn decode<R: std::io::Read>(
+            reader: &mut R,
+            ty: u8,
+        ) -> std::io::Result<Rmessage> {
+            match ty {
+                RPOST => Ok(Rmessage::Post(WireFormat::decode(reader)?)),
+                REVENTS => Ok(Rmessage::Events(WireFormat::decode(reader)?)),
+                RERROR => Ok(Rmessage::Error(WireFormat::decode(reader)?)),
+                RVERSION => Ok(Rmessage::Version(WireFormat::decode(reader)?)),
+                RDONE => Ok(Rmessage::Done(WireFormat::decode(reader)?)),
+                RCANCEL => Ok(Rmessage::CancelAck(WireFormat::decode(reader)?)),
+                _ => {
+                    Err(
+                        std::io::Error::new(
+                            std::io::ErrorKind::InvalidData,
+                            format!("unknown message type: {}", ty),
+                        ),
+                    )
+                }
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
+    pub struct RoomService<T: Room> {
+        pub inner: T,
+    }
+    impl<T> Protocol for RoomService<T>
+    where
+        T: Room + Send + Sync + Sized,
+    {
+        type Request = Tmessage;
+        type Response = Rmessage;
+        type Error = Error;
+        const VERSION: &'static str = PROTOCOL_VERSION;
+        const NAME: &'static str = PROTOCOL_NAME;
+        fn tcancel(oldtag: u16, binding: u64) -> Option<Tmessage> {
+            Some(
+                Tmessage::Cancel(jetstream::prelude::subscription::Tcancel {
+                    oldtag,
+                    binding,
+                }),
+            )
+        }
+    }
+    impl<T> Server for RoomService<T>
+    where
+        T: Room + Send + Sync + Sized,
+    {
+        fn rpc(
+            &mut self,
+            ctx: Context,
+            frame: Frame<<Self as Protocol>::Request>,
+        ) -> impl ::core::future::Future<
+            Output = Result<Frame<<Self as Protocol>::Response>>,
+        > + Send + Sync {
+            Box::pin(async move {
+                let req: <Self as Protocol>::Request = frame.msg;
+                let res: std::result::Result<
+                    <Self as Protocol>::Response,
+                    Self::Error,
+                > = match req {
+                    Tmessage::Version(tversion) => {
+                        use std::str::FromStr;
+                        let client_version = jetstream::prelude::Version::from_str(
+                                &tversion.version,
+                            )
+                            .map_err(|e| Error::new(e))?;
+                        match Self::version(client_version) {
+                            Ok(negotiated) => {
+                                Ok(
+                                    Rmessage::Version(jetstream::prelude::Rversion {
+                                        msize: tversion.msize,
+                                        version: negotiated.to_string(),
+                                    }),
+                                )
+                            }
+                            Err(_) => {
+                                Ok(
+                                    Rmessage::Version(jetstream::prelude::Rversion {
+                                        msize: 0,
+                                        version: "unknown".to_string(),
+                                    }),
+                                )
+                            }
+                        }
+                    }
+                    Tmessage::Cancel(_) => {
+                        Err(Error::new("a cancellation is not a unary call"))
+                    }
+                    Tmessage::Post(msg) => {
+                        match self.post(msg.body).await {
+                            Ok(result) => {
+                                let ret = Rpost(result);
+                                Ok(Rmessage::Post(ret))
+                            }
+                            Err(err) => Err(err.into()),
+                        }
+                    }
+                    Tmessage::Events(msg) => {
+                        let _ = msg;
+                        Err(
+                            Error::new(
+                                "a subscription cannot be answered with one frame",
+                            ),
+                        )
+                    }
+                };
+                let response = match res {
+                    Ok(msg) => msg,
+                    Err(err) => Rmessage::Error(err),
+                };
+                let rframe: Frame<<Self as Protocol>::Response> = Frame::from((
+                    frame.tag,
+                    response,
+                ));
+                Ok(rframe)
+            })
+        }
+        fn is_streaming(message_type: u8) -> bool {
+            matches!(message_type, TEVENTS)
+        }
+        fn cancel_target(frame: &Frame<Tmessage>) -> Option<u16> {
+            match &frame.msg {
+                Tmessage::Cancel(cancel) => Some(cancel.oldtag),
+                _ => None,
+            }
+        }
+        fn cancel_ack(oldtag: u16) -> Option<Rmessage> {
+            Some(
+                Rmessage::CancelAck(jetstream::prelude::subscription::Rcancel {
+                    oldtag,
+                }),
+            )
+        }
+        fn cancelled_terminator(_method: u8) -> Option<Rmessage> {
+            Some(Rmessage::Done(Done::Cancelled))
+        }
+        fn rpc_stream(
+            &mut self,
+            ctx: Context,
+            frame: Frame<<Self as Protocol>::Request>,
+            cancel: jetstream::prelude::subscription::CancellationToken,
+        ) -> impl ::core::future::Future<
+            Output = jetstream::prelude::server::ResponseStream<Self>,
+        > + Send + Sync {
+            Box::pin(async move {
+                let tag = frame.tag;
+                match frame.msg {
+                    Tmessage::Events(msg) => {
+                        let items = self.inner.events(msg.from).serve(cancel);
+                        Box::pin(
+                            jetstream::prelude::futures::StreamExt::map(
+                                items,
+                                move |item| match item {
+                                    Ok(Item::Next(value)) => {
+                                        Ok(Frame {
+                                            tag,
+                                            msg: Rmessage::Events(Revents(value)),
+                                        })
+                                    }
+                                    Ok(Item::Done(value)) => {
+                                        Ok(Frame {
+                                            tag,
+                                            msg: Rmessage::Done(Done::Events(ReventsDone(value))),
+                                        })
+                                    }
+                                    Err(err) => Err(err),
+                                },
+                            ),
+                        ) as jetstream::prelude::server::ResponseStream<Self>
+                    }
+                    _ => {
+                        Box::pin(jetstream::prelude::futures::stream::empty())
+                            as jetstream::prelude::server::ResponseStream<Self>
+                    }
+                }
+            })
+        }
+    }
+    impl<T> Room for RoomService<T>
+    where
+        T: Room + Send + Sync + Sized,
+    {
+        async fn post(&self, body: String) -> Result<u64, std::io::Error> {
+            self.inner.post(body).await
+        }
+        fn events(&self, from: u64) -> Subscription<Event, Closed> {
+            self.inner.events(from)
+        }
+    }
+    pub struct RoomChannel {
+        mux: std::sync::Arc<Mux<Self>>,
+    }
+    impl RoomChannel {
+        pub fn new(
+            max_concurrent_requests: u16,
+            inner: Box<dyn ClientTransport<Self>>,
+        ) -> Self {
+            Self {
+                mux: std::sync::Arc::new(Mux::new(max_concurrent_requests, inner)),
+            }
+        }
+        /// Perform Tversion/Rversion handshake with the server.
+        /// Must be called after `new()` and before any RPC calls.
+        pub async fn negotiate_version(
+            &self,
+            msize: u32,
+        ) -> std::result::Result<jetstream::prelude::Rversion, Error> {
+            let req = Tmessage::Version(jetstream::prelude::Tversion {
+                msize,
+                version: PROTOCOL_VERSION.to_string(),
+            });
+            let context = Context::default();
+            let rframe = self.mux.rpc(context, req).await.await?;
+            match rframe.msg {
+                Rmessage::Version(rversion) => {
+                    if rversion.version == "unknown" {
+                        Err(Error::new("server rejected version negotiation"))
+                    } else {
+                        Ok(rversion)
+                    }
+                }
+                Rmessage::Error(err) => Err(err),
+                _ => Err(Error::new("unexpected response to Tversion")),
+            }
+        }
+    }
+    impl Protocol for RoomChannel {
+        type Request = Tmessage;
+        type Response = Rmessage;
+        type Error = Error;
+        const VERSION: &'static str = PROTOCOL_VERSION;
+        const NAME: &'static str = PROTOCOL_NAME;
+        fn tcancel(oldtag: u16, binding: u64) -> Option<Tmessage> {
+            Some(
+                Tmessage::Cancel(jetstream::prelude::subscription::Tcancel {
+                    oldtag,
+                    binding,
+                }),
+            )
+        }
+    }
+    impl Room for RoomChannel {
+        async fn post(&self, body: String) -> Result<u64, std::io::Error> {
+            let req = Tmessage::Post(Tpost { body });
+            let context = Context::default();
+            let rframe = self.mux.rpc(context, req).await.await?;
+            let rmsg = rframe.msg;
+            match rmsg {
+                Rmessage::Post(msg) => Ok(msg.0),
+                Rmessage::Error(err) => Err(err),
+                _ => Err(Error::new("invalid reposne")),
+            }
+        }
+        fn events(&self, from: u64) -> Subscription<Event, Closed> {
+            let mux = self.mux.clone();
+            let req = Tmessage::Events(Tevents { from });
+            Subscription::opening(async move {
+                let frames = mux.rpc_stream(Context::default(), req, 64).await;
+                Subscription::from_frames(
+                    frames,
+                    |frame| {
+                        match frame.msg {
+                            Rmessage::Events(item) => Ok(Some(Item::Next(item.0))),
+                            Rmessage::Done(Done::Events(ReventsDone(value))) => {
+                                Ok(Some(Item::Done(value)))
+                            }
+                            Rmessage::Done(Done::Cancelled) => Ok(None),
+                            Rmessage::Error(err) => Err(err),
+                            _ => Err(Error::new("unexpected response in a subscription")),
+                        }
+                    },
+                )
+            })
+        }
+    }
+}
+#[jetstream::prelude::make(Send+Sync)]
+pub trait Room {
+    async fn post(&self, body: String) -> Result<u64, std::io::Error>;
+    fn events(&self, from: u64) -> Subscription<Event, Closed>;
+}

--- a/components/jetstream_macros/src/service/snapshots/jetstream_macros__service__tests__service_with_subscription.snap
+++ b/components/jetstream_macros/src/service/snapshots/jetstream_macros__service__tests__service_with_subscription.snap
@@ -363,7 +363,12 @@ pub mod room_protocol {
                                             msg: Rmessage::Done(Done::Events(ReventsDone(value))),
                                         })
                                     }
-                                    Err(err) => Err(err),
+                                    Err(err) => {
+                                        Ok(Frame {
+                                            tag,
+                                            msg: Rmessage::Error(err),
+                                        })
+                                    }
                                 },
                             ),
                         ) as jetstream::prelude::server::ResponseStream<Self>

--- a/components/jetstream_macros/src/service/snapshots/jetstream_macros__service__tests__service_with_uses.snap
+++ b/components/jetstream_macros/src/service/snapshots/jetstream_macros__service__tests__service_with_uses.snap
@@ -212,7 +212,7 @@ pub mod echo_protocol {
         }
     }
     pub struct EchoChannel {
-        mux: Mux<Self>,
+        mux: std::sync::Arc<Mux<Self>>,
     }
     impl EchoChannel {
         pub fn new(
@@ -220,7 +220,7 @@ pub mod echo_protocol {
             inner: Box<dyn ClientTransport<Self>>,
         ) -> Self {
             Self {
-                mux: Mux::new(max_concurrent_requests, inner),
+                mux: std::sync::Arc::new(Mux::new(max_concurrent_requests, inner)),
             }
         }
         /// Perform Tversion/Rversion handshake with the server.

--- a/components/jetstream_macros/src/service/snapshots/jetstream_macros__service__tests__simple_service.snap
+++ b/components/jetstream_macros/src/service/snapshots/jetstream_macros__service__tests__simple_service.snap
@@ -210,7 +210,7 @@ pub mod echo_protocol {
         }
     }
     pub struct EchoChannel {
-        mux: Mux<Self>,
+        mux: std::sync::Arc<Mux<Self>>,
     }
     impl EchoChannel {
         pub fn new(
@@ -218,7 +218,7 @@ pub mod echo_protocol {
             inner: Box<dyn ClientTransport<Self>>,
         ) -> Self {
             Self {
-                mux: Mux::new(max_concurrent_requests, inner),
+                mux: std::sync::Arc::new(Mux::new(max_concurrent_requests, inner)),
             }
         }
         /// Perform Tversion/Rversion handshake with the server.

--- a/components/jetstream_macros/src/service/snapshots/jetstream_macros__service__tests_tracing__service_multiple_methods_with_tracing.snap
+++ b/components/jetstream_macros/src/service/snapshots/jetstream_macros__service__tests_tracing__service_multiple_methods_with_tracing.snap
@@ -284,7 +284,7 @@ pub mod complexservice_protocol {
         }
     }
     pub struct ComplexServiceChannel {
-        mux: Mux<Self>,
+        mux: std::sync::Arc<Mux<Self>>,
     }
     impl ComplexServiceChannel {
         pub fn new(
@@ -292,7 +292,7 @@ pub mod complexservice_protocol {
             inner: Box<dyn ClientTransport<Self>>,
         ) -> Self {
             Self {
-                mux: Mux::new(max_concurrent_requests, inner),
+                mux: std::sync::Arc::new(Mux::new(max_concurrent_requests, inner)),
             }
         }
         /// Perform Tversion/Rversion handshake with the server.

--- a/components/jetstream_macros/src/service/snapshots/jetstream_macros__service__tests_tracing__service_with_custom_instrument.snap
+++ b/components/jetstream_macros/src/service/snapshots/jetstream_macros__service__tests_tracing__service_with_custom_instrument.snap
@@ -218,7 +218,7 @@ pub mod echo_protocol {
         }
     }
     pub struct EchoChannel {
-        mux: Mux<Self>,
+        mux: std::sync::Arc<Mux<Self>>,
     }
     impl EchoChannel {
         pub fn new(
@@ -226,7 +226,7 @@ pub mod echo_protocol {
             inner: Box<dyn ClientTransport<Self>>,
         ) -> Self {
             Self {
-                mux: Mux::new(max_concurrent_requests, inner),
+                mux: std::sync::Arc::new(Mux::new(max_concurrent_requests, inner)),
             }
         }
         /// Perform Tversion/Rversion handshake with the server.

--- a/components/jetstream_macros/src/service/snapshots/jetstream_macros__service__tests_tracing__service_with_instrument_attribute.snap
+++ b/components/jetstream_macros/src/service/snapshots/jetstream_macros__service__tests_tracing__service_with_instrument_attribute.snap
@@ -213,7 +213,7 @@ pub mod echo_protocol {
         }
     }
     pub struct EchoChannel {
-        mux: Mux<Self>,
+        mux: std::sync::Arc<Mux<Self>>,
     }
     impl EchoChannel {
         pub fn new(
@@ -221,7 +221,7 @@ pub mod echo_protocol {
             inner: Box<dyn ClientTransport<Self>>,
         ) -> Self {
             Self {
-                mux: Mux::new(max_concurrent_requests, inner),
+                mux: std::sync::Arc::new(Mux::new(max_concurrent_requests, inner)),
             }
         }
         /// Perform Tversion/Rversion handshake with the server.

--- a/components/jetstream_macros/src/service/snapshots/jetstream_macros__service__tests_tracing__service_with_tracing_and_manual_override.snap
+++ b/components/jetstream_macros/src/service/snapshots/jetstream_macros__service__tests_tracing__service_with_tracing_and_manual_override.snap
@@ -248,7 +248,7 @@ pub mod echo_protocol {
         }
     }
     pub struct EchoChannel {
-        mux: Mux<Self>,
+        mux: std::sync::Arc<Mux<Self>>,
     }
     impl EchoChannel {
         pub fn new(
@@ -256,7 +256,7 @@ pub mod echo_protocol {
             inner: Box<dyn ClientTransport<Self>>,
         ) -> Self {
             Self {
-                mux: Mux::new(max_concurrent_requests, inner),
+                mux: std::sync::Arc::new(Mux::new(max_concurrent_requests, inner)),
             }
         }
         /// Perform Tversion/Rversion handshake with the server.

--- a/components/jetstream_macros/src/service/snapshots/jetstream_macros__service__tests_tracing__service_with_tracing_enabled.snap
+++ b/components/jetstream_macros/src/service/snapshots/jetstream_macros__service__tests_tracing__service_with_tracing_enabled.snap
@@ -217,7 +217,7 @@ pub mod echo_protocol {
         }
     }
     pub struct EchoChannel {
-        mux: Mux<Self>,
+        mux: std::sync::Arc<Mux<Self>>,
     }
     impl EchoChannel {
         pub fn new(
@@ -225,7 +225,7 @@ pub mod echo_protocol {
             inner: Box<dyn ClientTransport<Self>>,
         ) -> Self {
             Self {
-                mux: Mux::new(max_concurrent_requests, inner),
+                mux: std::sync::Arc::new(Mux::new(max_concurrent_requests, inner)),
             }
         }
         /// Perform Tversion/Rversion handshake with the server.

--- a/components/jetstream_macros/src/service/subscription.rs
+++ b/components/jetstream_macros/src/service/subscription.rs
@@ -1,0 +1,191 @@
+//! `#[subscription]`: the declaration that makes a method streaming.
+//!
+//! r[impl jetstream.subscription.surface.declared]
+//! The declaration is the protocol's, not the call site's — a dispatcher
+//! has to route on it before it decodes the payload, and a caller must
+//! not be able to turn a unary method into a subscription by asking
+//! differently.
+
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
+use syn::{Ident, TraitItemFn, Type};
+
+/// A method declared `#[subscription]`.
+pub struct Streaming {
+    /// `T` in `Subscription<T, D>` — one item of the sequence.
+    pub item: Type,
+    /// `D` — what the end carries.
+    pub done: Type,
+}
+
+// r[impl jetstream.subscription.lossy.declared]
+// `lossy` is parsed and refused rather than carried: nothing downstream
+// can act on it yet, and a field nobody reads is a promise nobody keeps.
+
+/// Find `#[subscription]` on a method, take it off, and read the types
+/// out of the return position.
+///
+/// Taking it off matters: the attribute is the macro's own, and a trait
+/// emitted with it still attached does not compile.
+pub fn take(method: &mut TraitItemFn) -> Result<Option<Streaming>, syn::Error> {
+    let Some(at) = method
+        .attrs
+        .iter()
+        .position(|a| a.path().is_ident("subscription"))
+    else {
+        return Ok(None);
+    };
+    let attr = method.attrs.remove(at);
+
+    let mut lossy = false;
+    if !matches!(attr.meta, syn::Meta::Path(_)) {
+        attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("lossy") {
+                lossy = true;
+                Ok(())
+            } else {
+                Err(meta.error("expected `lossy`"))
+            }
+        })?;
+    }
+
+    if lossy {
+        return Err(syn::Error::new_spanned(
+            &method.sig.ident,
+            "#[subscription(lossy)] is not implemented yet: the datagram \
+             realisation it needs has not landed. Accepting it here would \
+             give a reliable subscription to a caller who asked for a \
+             lossy one, which is worse than refusing.",
+        ));
+    }
+
+    let (item, done) = subscription_types(method)?;
+    Ok(Some(Streaming { item, done }))
+}
+
+/// Read `T` and `D` out of `-> Subscription<T, D>`.
+fn subscription_types(
+    method: &TraitItemFn,
+) -> Result<(Type, Type), syn::Error> {
+    let bad = |span| {
+        syn::Error::new(
+            span,
+            "a #[subscription] method must return `Subscription<Item, Done>`",
+        )
+    };
+
+    let syn::ReturnType::Type(_, ty) = &method.sig.output else {
+        return Err(bad(method.sig.ident.span()));
+    };
+    let Type::Path(path) = &**ty else {
+        return Err(bad(method.sig.ident.span()));
+    };
+    let Some(last) = path.path.segments.last() else {
+        return Err(bad(method.sig.ident.span()));
+    };
+    if last.ident != "Subscription" {
+        return Err(bad(method.sig.ident.span()));
+    }
+    let syn::PathArguments::AngleBracketed(args) = &last.arguments else {
+        return Err(bad(method.sig.ident.span()));
+    };
+    let mut types = args.args.iter().filter_map(|a| match a {
+        syn::GenericArgument::Type(t) => Some(t.clone()),
+        _ => None,
+    });
+    match (types.next(), types.next()) {
+        (Some(item), Some(done)) => Ok((item, done)),
+        _ => Err(bad(method.sig.ident.span())),
+    }
+}
+
+/// The name of the struct holding a subscription's terminal value.
+pub fn done_struct_name(return_struct: &Ident) -> Ident {
+    format_ident!("{}Done", return_struct)
+}
+
+/// r[impl jetstream.subscription.termination.discriminant]
+/// The terminator enum: one variant per streaming method, encoded with
+/// the message id of the request that opened the subscription in front
+/// of it.
+///
+/// `RDONE` is one **global** message id, which is what keeps
+/// `102 + 2 * index` intact for every other method — and a protocol with
+/// two subscription methods then has two terminal types under that one
+/// id. The tag would tell them apart, and `decode` never sees the tag.
+/// So the payload names its method.
+pub fn generate_done_enum(variants: &[(Ident, Ident, Ident)]) -> TokenStream {
+    // (variant name, done struct, request message id const)
+    let decls = variants.iter().map(|(variant, done, _)| {
+        quote! { #variant(#done), }
+    });
+    let byte_sizes = variants.iter().map(|(variant, ..)| {
+        quote! { Done::#variant(v) => 1 + v.byte_size() }
+    });
+    let encodes = variants.iter().map(|(variant, _, id)| {
+        quote! {
+            Done::#variant(v) => {
+                WireFormat::encode(&#id, writer)?;
+                v.encode(writer)
+            }
+        }
+    });
+    let decodes = variants.iter().map(|(variant, _, id)| {
+        quote! {
+            #id => Ok(Done::#variant(WireFormat::decode(reader)?)),
+        }
+    });
+
+    quote! {
+        /// r[impl jetstream.subscription.dispatch.terminator]
+        /// The end of a subscription, and what it ended with. The
+        /// payload names its method, because `RDONE` is one global id
+        /// and a decoder is handed the type byte alone.
+        #[derive(Debug)]
+        pub enum Done {
+            #(#decls)*
+            /// r[impl jetstream.subscription.dispatch.terminator]
+            /// The subscription was cut short, so it carries no result:
+            /// a producer stopped by cancellation never produced one,
+            /// and a default value in its place would report a result
+            /// that did not happen. Its only job is to free the tag.
+            ///
+            /// Method id zero, which no method can have —
+            /// `MESSAGE_ID_START` is 102.
+            Cancelled,
+        }
+
+        impl WireFormat for Done {
+            fn byte_size(&self) -> u32 {
+                match self {
+                    #(#byte_sizes,)*
+                    Done::Cancelled => 1,
+                }
+            }
+
+            fn encode<W: std::io::Write>(
+                &self,
+                writer: &mut W,
+            ) -> std::io::Result<()> {
+                match self {
+                    #(#encodes,)*
+                    Done::Cancelled => WireFormat::encode(&0u8, writer),
+                }
+            }
+
+            fn decode<R: std::io::Read>(
+                reader: &mut R,
+            ) -> std::io::Result<Self> {
+                let method: u8 = WireFormat::decode(reader)?;
+                match method {
+                    0u8 => Ok(Done::Cancelled),
+                    #(#decodes)*
+                    other => Err(std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        format!("terminator for an unknown method: {}", other),
+                    )),
+                }
+            }
+        }
+    }
+}

--- a/components/jetstream_macros/src/service/tests.rs
+++ b/components/jetstream_macros/src/service/tests.rs
@@ -172,6 +172,45 @@ fn test_service_with_subscription() {
     })
 }
 
+/// r[verify jetstream.macro.tracing-instrument]
+/// A subscription handler must be reached through the generated
+/// wrapper, which is where `#[tracing::instrument]` is installed. Unary
+/// dispatch calls `self.<method>`; serving a subscription called
+/// `self.inner.<method>` and so was the one call whose span silently
+/// went missing in a `#[service(tracing)]` service.
+#[test]
+fn a_traced_subscription_is_served_through_the_instrumented_wrapper() {
+    let input: syn::ItemTrait = parse_quote! {
+        pub trait Room {
+            async fn post(&self, body: String) -> Result<u64, std::io::Error>;
+            #[subscription]
+            fn events(&self, from: u64) -> Subscription<Event, Closed>;
+        }
+    };
+    let attr = parse_service_attr(quote! { tracing });
+    let output = service_impl(input, attr);
+    let syntax_tree: syn::File = syn::parse2(output).unwrap();
+    let rendered = prettyplease::unparse(&syntax_tree);
+
+    // The wrapper exists and carries the instrumentation.
+    assert!(
+        rendered.contains("#[tracing::instrument(skip(self))]"),
+        "the tracing service emitted no instrumentation",
+    );
+    // And serving goes through it rather than around it.
+    assert!(
+        rendered.contains(".events(msg.from).serve(cancel)"),
+        "serving must call the wrapper, not the inner trait",
+    );
+    // The wrapper's own body calls the inner trait — that is what a
+    // wrapper is. What must not appear is the *serve* arm doing it,
+    // which is the call that reads its arguments out of `msg`.
+    assert!(
+        !rendered.contains("self.inner.events(msg."),
+        "serving bypassed the wrapper, losing the subscription's span",
+    );
+}
+
 /// r[verify jetstream.subscription.compat.rpc-layer]
 /// A protocol with no subscriptions must emit none of the machinery —
 /// no cancellation variant, no terminator, no dispatcher hooks — so it

--- a/components/jetstream_macros/src/service/tests.rs
+++ b/components/jetstream_macros/src/service/tests.rs
@@ -1,9 +1,11 @@
 #![cfg(test)]
 
-use super::{parse_service_attr, service_impl, ServiceAttr};
 use core::panic;
+
 use quote::quote;
 use syn::parse_quote;
+
+use super::{parse_service_attr, service_impl, ServiceAttr};
 
 fn run_test_with_filters<F>(test_fn: F)
 where
@@ -148,4 +150,111 @@ fn test_service_with_uses() {
     run_test_with_filters(|| {
         insta::assert_snapshot!(output_str);
     })
+}
+
+/// r[verify jetstream.subscription.surface.declared]
+/// r[verify jetstream.subscription.termination.discriminant]
+/// r[verify jetstream.subscription.dispatch.declared]
+#[test]
+fn test_service_with_subscription() {
+    let input: syn::ItemTrait = parse_quote! {
+        pub trait Room {
+            async fn post(&self, body: String) -> Result<u64, std::io::Error>;
+            #[subscription]
+            fn events(&self, from: u64) -> Subscription<Event, Closed>;
+        }
+    };
+    let output = service_impl(input, ServiceAttr::default());
+    let syntax_tree: syn::File = syn::parse2(output).unwrap();
+    let output_str = prettyplease::unparse(&syntax_tree);
+    run_test_with_filters(|| {
+        insta::assert_snapshot!(output_str);
+    })
+}
+
+/// r[verify jetstream.subscription.compat.rpc-layer]
+/// A protocol with no subscriptions must emit none of the machinery —
+/// no cancellation variant, no terminator, no dispatcher hooks — so it
+/// compiles exactly as it did before subscriptions existed.
+#[test]
+fn a_protocol_without_subscriptions_gains_nothing() {
+    let input: syn::ItemTrait = parse_quote! {
+        pub trait Echo {
+            async fn ping(&self, message: String) -> Result<String, std::io::Error>;
+        }
+    };
+    let output = service_impl(input, ServiceAttr::default()).to_string();
+    for absent in [
+        "Cancel",
+        "CancelAck",
+        "RDONE",
+        "TCANCEL",
+        "RCANCEL",
+        "is_streaming",
+        "rpc_stream",
+        "cancelled_terminator",
+        "enum Done",
+    ] {
+        assert!(
+            !output.contains(absent),
+            "a protocol with no subscriptions emitted `{absent}`"
+        );
+    }
+}
+
+/// r[verify jetstream.subscription.compat]
+/// The per-method ids are untouched by a streaming method: the
+/// terminator and cancellation live below `MESSAGE_ID_START`, which is
+/// the whole reason they were put there.
+#[test]
+fn a_subscription_costs_no_per_method_id() {
+    let input: syn::ItemTrait = parse_quote! {
+        pub trait Room {
+            #[subscription]
+            fn events(&self, from: u64) -> Subscription<Event, Closed>;
+            async fn post(&self, body: String) -> Result<u64, std::io::Error>;
+        }
+    };
+    let output = service_impl(input, ServiceAttr::default()).to_string();
+    // `events` is index 0 and `post` index 1, exactly as they would be
+    // if neither streamed.
+    assert!(output.contains("TEVENTS : u8 = MESSAGE_ID_START + 0u8"));
+    assert!(output.contains("TPOST : u8 = MESSAGE_ID_START + 2u8"));
+}
+
+/// A `#[subscription]` method has to say what it yields and what it
+/// ends with, and the error has to say so rather than failing somewhere
+/// inside the generated code.
+#[test]
+fn a_subscription_must_return_a_subscription() {
+    let input: syn::ItemTrait = parse_quote! {
+        pub trait Room {
+            #[subscription]
+            fn events(&self, from: u64) -> Vec<Event>;
+        }
+    };
+    let output = service_impl(input, ServiceAttr::default()).to_string();
+    assert!(
+        output.contains("must return `Subscription<Item, Done>`"),
+        "expected a compile error naming the required return type: {output}"
+    );
+}
+
+/// r[verify jetstream.subscription.lossy.declared]
+/// Refused rather than quietly served reliably: a caller told they have
+/// a lossy subscription, who in fact has a reliable one, has been
+/// misinformed about delivery.
+#[test]
+fn lossy_is_refused_until_it_exists() {
+    let input: syn::ItemTrait = parse_quote! {
+        pub trait Room {
+            #[subscription(lossy)]
+            fn presence(&self) -> Subscription<Who, Closed>;
+        }
+    };
+    let output = service_impl(input, ServiceAttr::default()).to_string();
+    assert!(
+        output.contains("not implemented yet"),
+        "expected lossy to be refused: {output}"
+    );
 }

--- a/components/jetstream_rpc/src/subscription.rs
+++ b/components/jetstream_rpc/src/subscription.rs
@@ -207,6 +207,18 @@ impl<T, D> Item<T, D> {
 /// `r[jetstream.subscription.realisation.opaque]`.
 pub struct Subscription<T, D> {
     source: Source<T, D>,
+    /// Cancels the fallback token handed to a producer that was polled
+    /// without a dispatcher, when this subscription is dropped.
+    ///
+    /// r[impl jetstream.subscription.surface.cancellation]
+    /// Without it, a producer served in process — polled directly rather
+    /// than through `serve` — held a token nothing would ever cancel, so
+    /// dropping the subscription woke nothing. For `producing`, whose
+    /// body runs in a spawned task, that task then outlived the receiver
+    /// it was sending to: the exact "the work carries on with nowhere to
+    /// deliver" that cancellation exists to prevent, in the one case
+    /// where no dispatcher is around to notice.
+    fallback: Option<tokio_util::sync::DropGuard>,
 }
 
 /// Where a subscription's items come from.
@@ -276,6 +288,7 @@ where
     {
         use futures::StreamExt;
         Subscription {
+            fallback: None,
             source: Source::Open(Box::pin(
                 stream
                     .map(move |frame| decode(frame?))
@@ -307,6 +320,7 @@ where
         F: std::future::Future<Output = Self> + Send + 'static,
     {
         Subscription {
+            fallback: None,
             source: Source::Opening(Box::pin(async move {
                 match open.await.source {
                     Source::Open(items) => items,
@@ -340,14 +354,20 @@ where
     /// nothing can. A subscription that must not miss anything says
     /// where to start, and its producer replays from there; that is
     /// what the cursor in `r[jetstream.subscription.resume]` is for.
+    /// Cancel-safe: the opening future stays *in* the subscription while
+    /// it is awaited.
+    ///
+    /// It used to be moved out and `Source::Taken` left in its place, so
+    /// dropping this future — a timeout, a losing `select!` branch —
+    /// dropped the only opening future with it and left the subscription
+    /// permanently `Taken`: a second `establish()` did nothing at all,
+    /// and the next poll hit an `unreachable!`. Awaiting in place means
+    /// an abandoned establishment leaves the subscription exactly as it
+    /// was, ready to be established or polled again.
     pub async fn establish(&mut self) {
-        if let Source::Opening(_) = self.source {
-            let Source::Opening(open) =
-                std::mem::replace(&mut self.source, Source::Taken)
-            else {
-                unreachable!("checked immediately above")
-            };
-            self.source = Source::Open(open.await);
+        if let Source::Opening(open) = &mut self.source {
+            let items = open.as_mut().await;
+            self.source = Source::Open(items);
         }
     }
 
@@ -362,6 +382,7 @@ where
             + 'static,
     {
         Subscription {
+            fallback: None,
             source: Source::Awaiting(Box::new(move |cancel| {
                 Box::pin(produce(cancel))
             })),
@@ -417,6 +438,7 @@ where
             + 'static,
     {
         Subscription {
+            fallback: None,
             source: Source::Open(Box::pin(items)),
         }
     }
@@ -458,7 +480,13 @@ impl<T, D> futures::Stream for Subscription<T, D> {
             else {
                 unreachable!("checked immediately above")
             };
-            self.source = Source::Open(produce(CancellationToken::new()));
+            // No dispatcher, so nothing else owns a token — but the
+            // producer still has to learn when this subscription goes,
+            // or a `producing` task outlives the receiver it is sending
+            // to. The guard cancels it on drop.
+            let cancel = CancellationToken::new();
+            self.fallback = Some(cancel.clone().drop_guard());
+            self.source = Source::Open(produce(cancel));
         }
         match &mut self.source {
             Source::Open(items) => items.as_mut().poll_next(cx),

--- a/components/jetstream_rpc/src/subscription.rs
+++ b/components/jetstream_rpc/src/subscription.rs
@@ -263,6 +263,36 @@ pub type ItemStream<T, D> = std::pin::Pin<
     Box<dyn futures::Stream<Item = jetstream_error::Result<Item<T, D>>> + Send>,
 >;
 
+/// Keep a cancellation guard alive for exactly as long as the stream it
+/// belongs to.
+///
+/// r[impl jetstream.subscription.surface.cancellation]
+/// A guard cancels when it drops, so where it lives decides when the
+/// producer stops. Left on a `Subscription` that is being taken apart,
+/// it fires while the stream it protects is still about to be read;
+/// folded into that stream's own state, it lasts precisely as long as
+/// something is reading.
+fn carrying<T, D>(
+    items: ItemStream<T, D>,
+    guard: Option<tokio_util::sync::DropGuard>,
+) -> ItemStream<T, D>
+where
+    T: Send + 'static,
+    D: Send + 'static,
+{
+    let Some(guard) = guard else {
+        return items;
+    };
+    Box::pin(futures::stream::unfold(
+        (items, guard),
+        |(mut items, guard)| async move {
+            use futures::StreamExt as _;
+            let item = items.next().await?;
+            Some((item, (items, guard)))
+        },
+    ))
+}
+
 /// What opening a subscription yields: the sequence, and whatever has to
 /// stay alive to cancel its producer.
 ///
@@ -471,32 +501,32 @@ where
     /// caller's — ignores the token, which is right: nothing on that
     /// side produces.
     pub fn serve(self, cancel: CancellationToken) -> ItemStream<T, D> {
-        match self.source {
-            Source::Open(items) => items,
+        // Taken apart rather than matched through, because the guard is
+        // as much a part of this subscription as its source. Matching on
+        // `self.source` alone leaves the rest of `self` to be dropped
+        // when `serve` returns — and if it holds a guard, that cancels
+        // the producer whose stream is being handed back.
+        let Subscription { source, fallback } = self;
+        match source {
+            // r[impl jetstream.subscription.surface.cancellation]
+            // Already a sequence, but not necessarily someone else's: a
+            // subscription that opened onto its own producer — through
+            // `establish` or a poll — carries the guard for it, and that
+            // guard has to reach the returned stream.
+            Source::Open(items) => carrying(items, fallback),
             Source::Awaiting(produce) => produce(cancel),
             // A caller's subscription served as a producer's: it opens
             // itself, and the dispatcher's token has nothing to cancel
             // here.
             //
-            // r[impl jetstream.subscription.surface.cancellation]
             // Opening may still hand back a guard of its own, for a
-            // producer nested inside it. That guard becomes part of the
-            // stream's state so it lives exactly as long as the stream —
-            // dropping it when the future resolved would cancel the very
-            // producer whose items are about to be read.
+            // producer nested inside it.
             Source::Opening(open) => {
                 use futures::StreamExt as _;
-                Box::pin(futures::stream::once(open).flat_map(
-                    |(items, guard)| {
-                        futures::stream::unfold(
-                            (items, guard),
-                            |(mut items, guard)| async move {
-                                let item = items.next().await?;
-                                Some((item, (items, guard)))
-                            },
-                        )
-                    },
-                ))
+                Box::pin(
+                    futures::stream::once(open)
+                        .flat_map(|(items, guard)| carrying(items, guard)),
+                )
             }
             Source::Taken => unreachable!("only set while being replaced"),
         }

--- a/components/jetstream_rpc/src/subscription.rs
+++ b/components/jetstream_rpc/src/subscription.rs
@@ -225,6 +225,20 @@ pub struct Subscription<T, D> {
 /// one — in a test, or in process — it gets a token nothing cancels,
 /// which is the truth of that situation.
 enum Source<T, D> {
+    /// Opening: the request is not on the wire yet.
+    ///
+    /// r[impl jetstream.subscription.surface.rust]
+    /// A subscription opens on first poll, which is what lets the
+    /// method be the plain `fn` the surface calls for. It also means
+    /// "subscribe, then act, then read" is a race — nothing reached the
+    /// service. [`Subscription::establish`] is the way to say "now",
+    /// and it exists because writing the usage kept tripping over its
+    /// absence.
+    Opening(
+        std::pin::Pin<
+            Box<dyn std::future::Future<Output = ItemStream<T, D>> + Send>,
+        >,
+    ),
     Open(ItemStream<T, D>),
     Awaiting(Box<dyn FnOnce(CancellationToken) -> ItemStream<T, D> + Send>),
     /// Momentarily empty while the one above is being run. A variant
@@ -292,11 +306,48 @@ where
     where
         F: std::future::Future<Output = Self> + Send + 'static,
     {
-        use futures::StreamExt;
         Subscription {
-            source: Source::Open(Box::pin(
-                futures::stream::once(open).flatten(),
-            )),
+            source: Source::Opening(Box::pin(async move {
+                match open.await.source {
+                    Source::Open(items) => items,
+                    // An opener that hands back a producer's
+                    // subscription has nothing to produce into; it gets
+                    // a token nothing cancels, as it would on poll.
+                    Source::Awaiting(produce) => {
+                        produce(CancellationToken::new())
+                    }
+                    Source::Opening(inner) => inner.await,
+                    Source::Taken => {
+                        unreachable!("only set while being replaced")
+                    }
+                }
+            })),
+        }
+    }
+
+    /// Put the request on the wire now, rather than at the first read.
+    ///
+    /// r[impl jetstream.subscription.surface.rust]
+    /// Opening lazily is what keeps the method signature a plain `fn`,
+    /// and it makes "subscribe, then act, then read" a race: the act
+    /// happens before the subscription exists. Awaiting this first
+    /// removes that race **on one lane**, where
+    /// `r[jetstream.lane.delivery-order]` then orders the request ahead
+    /// of whatever follows it.
+    ///
+    /// It does **not** order a subscription against a call on a
+    /// *different* lane — `r[jetstream.lane.no-cross-lane-order]` — and
+    /// nothing can. A subscription that must not miss anything says
+    /// where to start, and its producer replays from there; that is
+    /// what the cursor in `r[jetstream.subscription.resume]` is for.
+    pub async fn establish(&mut self) {
+        if let Source::Opening(_) = self.source {
+            let Source::Opening(open) =
+                std::mem::replace(&mut self.source, Source::Taken)
+            else {
+                unreachable!("checked immediately above")
+            };
+            self.source = Source::Open(open.await);
         }
     }
 
@@ -348,6 +399,11 @@ where
         match self.source {
             Source::Open(items) => items,
             Source::Awaiting(produce) => produce(cancel),
+            // A caller's subscription served as a producer's: it opens
+            // itself, and the token has nothing to cancel here.
+            Source::Opening(open) => Box::pin(futures::StreamExt::flatten(
+                futures::stream::once(open),
+            )),
             Source::Taken => unreachable!("only set while being replaced"),
         }
     }
@@ -388,6 +444,14 @@ impl<T, D> futures::Stream for Subscription<T, D> {
         // A producer's subscription polled without a dispatcher gets a
         // token nothing cancels. Nothing here can cancel it, so saying
         // otherwise would be a lie.
+        if let Source::Opening(open) = &mut self.source {
+            match open.as_mut().poll(cx) {
+                std::task::Poll::Ready(items) => {
+                    self.source = Source::Open(items);
+                }
+                std::task::Poll::Pending => return std::task::Poll::Pending,
+            }
+        }
         if let Source::Awaiting(_) = self.source {
             let Source::Awaiting(produce) =
                 std::mem::replace(&mut self.source, Source::Taken)

--- a/components/jetstream_rpc/src/subscription.rs
+++ b/components/jetstream_rpc/src/subscription.rs
@@ -248,7 +248,7 @@ enum Source<T, D> {
     /// absence.
     Opening(
         std::pin::Pin<
-            Box<dyn std::future::Future<Output = ItemStream<T, D>> + Send>,
+            Box<dyn std::future::Future<Output = Opened<T, D>> + Send>,
         >,
     ),
     Open(ItemStream<T, D>),
@@ -262,6 +262,18 @@ enum Source<T, D> {
 pub type ItemStream<T, D> = std::pin::Pin<
     Box<dyn futures::Stream<Item = jetstream_error::Result<Item<T, D>>> + Send>,
 >;
+
+/// What opening a subscription yields: the sequence, and whatever has to
+/// stay alive to cancel its producer.
+///
+/// r[impl jetstream.subscription.surface.cancellation]
+/// The guard travels *out* of the opening future because it has to
+/// outlive it. Opening runs inside a boxed future that cannot reach the
+/// subscription the caller holds, so a token created in there had no
+/// owner: dropping the subscription woke nothing, and a `producing`
+/// task went on sending to a receiver that was gone. Handing the guard
+/// back is what puts it where the drop can reach it.
+type Opened<T, D> = (ItemStream<T, D>, Option<tokio_util::sync::DropGuard>);
 
 impl<T, D> Subscription<T, D>
 where
@@ -339,14 +351,30 @@ where
         Subscription {
             fallback: None,
             source: Source::Opening(Box::pin(async move {
-                match open.await.source {
-                    Source::Open(items) => items,
+                let mut opened = open.await;
+                // Taken out rather than matched on, so `opened` stays
+                // whole until its guard has been claimed below. Letting
+                // it drop here would fire that guard and cancel the very
+                // producer this is about to return.
+                let source =
+                    std::mem::replace(&mut opened.source, Source::Taken);
+                match source {
+                    Source::Open(items) => (items, opened.fallback.take()),
+                    // r[impl jetstream.subscription.surface.cancellation]
                     // An opener that hands back a producer's
-                    // subscription has nothing to produce into; it gets
-                    // a token nothing cancels, as it would on poll.
+                    // subscription is the polled case one step removed:
+                    // the producer needs a token, and something has to
+                    // own the cancelling end of it. This used to make a
+                    // token and drop the only handle to it, so a
+                    // `producing` task spawned through `opening` could
+                    // outlive its subscriber with nothing to stop it.
                     Source::Awaiting(produce) => {
-                        produce(CancellationToken::new())
+                        let cancel = CancellationToken::new();
+                        let guard = cancel.clone().drop_guard();
+                        (produce(cancel), Some(guard))
                     }
+                    // Nested: the inner future has already done this and
+                    // carries its own guard out.
                     Source::Opening(inner) => inner.await,
                     Source::Taken => {
                         unreachable!("only set while being replaced")
@@ -383,8 +411,14 @@ where
     /// was, ready to be established or polled again.
     pub async fn establish(&mut self) {
         if let Source::Opening(open) = &mut self.source {
-            let items = open.as_mut().await;
+            let (items, guard) = open.as_mut().await;
             self.source = Source::Open(items);
+            // Only when opening produced one: a subscription that opened
+            // onto a dispatcher-served stream has nothing to cancel here,
+            // and must not lose a guard it already held.
+            if guard.is_some() {
+                self.fallback = guard;
+            }
         }
     }
 
@@ -441,10 +475,29 @@ where
             Source::Open(items) => items,
             Source::Awaiting(produce) => produce(cancel),
             // A caller's subscription served as a producer's: it opens
-            // itself, and the token has nothing to cancel here.
-            Source::Opening(open) => Box::pin(futures::StreamExt::flatten(
-                futures::stream::once(open),
-            )),
+            // itself, and the dispatcher's token has nothing to cancel
+            // here.
+            //
+            // r[impl jetstream.subscription.surface.cancellation]
+            // Opening may still hand back a guard of its own, for a
+            // producer nested inside it. That guard becomes part of the
+            // stream's state so it lives exactly as long as the stream —
+            // dropping it when the future resolved would cancel the very
+            // producer whose items are about to be read.
+            Source::Opening(open) => {
+                use futures::StreamExt as _;
+                Box::pin(futures::stream::once(open).flat_map(
+                    |(items, guard)| {
+                        futures::stream::unfold(
+                            (items, guard),
+                            |(mut items, guard)| async move {
+                                let item = items.next().await?;
+                                Some((item, (items, guard)))
+                            },
+                        )
+                    },
+                ))
+            }
             Source::Taken => unreachable!("only set while being replaced"),
         }
     }
@@ -483,13 +536,17 @@ impl<T, D> futures::Stream for Subscription<T, D> {
         mut self: std::pin::Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Option<Self::Item>> {
-        // A producer's subscription polled without a dispatcher gets a
-        // token nothing cancels. Nothing here can cancel it, so saying
-        // otherwise would be a lie.
+        // r[impl jetstream.subscription.surface.cancellation]
+        // A producer polled without a dispatcher still gets a token that
+        // something owns — the guard below, or the one opening hands
+        // back here. Both paths reach a producer, so both have to.
         if let Source::Opening(open) = &mut self.source {
             match open.as_mut().poll(cx) {
-                std::task::Poll::Ready(items) => {
+                std::task::Poll::Ready((items, guard)) => {
                     self.source = Source::Open(items);
+                    if guard.is_some() {
+                        self.fallback = guard;
+                    }
                 }
                 std::task::Poll::Pending => return std::task::Poll::Pending,
             }

--- a/components/jetstream_rpc/src/subscription.rs
+++ b/components/jetstream_rpc/src/subscription.rs
@@ -206,7 +206,30 @@ impl<T, D> Item<T, D> {
 /// its own or a tag on a shared one, per
 /// `r[jetstream.subscription.realisation.opaque]`.
 pub struct Subscription<T, D> {
-    items: ItemStream<T, D>,
+    source: Source<T, D>,
+}
+
+/// Where a subscription's items come from.
+///
+/// r[impl jetstream.subscription.surface.producer]
+/// A subscription is one type on both sides of the call, because one
+/// trait describes both — and the two sides need different things. A
+/// caller needs a sequence. A producer needs cancellation, which the
+/// trait's signature has nowhere to put: `fn events(&self, ctx, from)
+/// -> Subscription<Event, Closed>` names no token, and adding one would
+/// put a parameter in the caller's signature that means nothing to a
+/// caller.
+///
+/// So a producer's subscription is a function *awaiting* its token, and
+/// the dispatcher supplies it when it serves the call. Polled without
+/// one — in a test, or in process — it gets a token nothing cancels,
+/// which is the truth of that situation.
+enum Source<T, D> {
+    Open(ItemStream<T, D>),
+    Awaiting(Box<dyn FnOnce(CancellationToken) -> ItemStream<T, D> + Send>),
+    /// Momentarily empty while the one above is being run. A variant
+    /// rather than an `Option` so replacing it needs no bound on `T`.
+    Taken,
 }
 
 /// The boxed sequence a `Subscription` reads: items, then the end.
@@ -222,19 +245,110 @@ where
     /// Build one from the frames of a streaming call. `decode` is the
     /// generated protocol's: only it knows which response variant is an
     /// item and which is the terminator.
+    /// `decode` returns `None` for a frame that ends the subscription
+    /// **without** an item — the terminator of a subscription cut
+    /// short, which frees the tag and carries no result, because a
+    /// producer stopped by cancellation never produced one. Fabricating
+    /// a default there would report a result that did not happen.
     pub fn from_frames<P, F>(stream: crate::RpcStream<P>, mut decode: F) -> Self
     where
         P: crate::Protocol + 'static,
         P::Response: 'static,
         F: FnMut(
                 crate::Frame<P::Response>,
-            ) -> jetstream_error::Result<Item<T, D>>
+            ) -> jetstream_error::Result<Option<Item<T, D>>>
             + Send
             + 'static,
     {
         use futures::StreamExt;
         Subscription {
-            items: Box::pin(stream.map(move |frame| decode(frame?))),
+            source: Source::Open(Box::pin(
+                stream
+                    .map(move |frame| decode(frame?))
+                    .take_while(|decoded| {
+                        futures::future::ready(!matches!(decoded, Ok(None)))
+                    })
+                    .filter_map(|decoded| {
+                        futures::future::ready(match decoded {
+                            Ok(Some(item)) => Some(Ok(item)),
+                            Ok(None) => None,
+                            Err(e) => Some(Err(e)),
+                        })
+                    }),
+            )),
+        }
+    }
+
+    /// Build one that opens when it is first polled.
+    ///
+    /// r[impl jetstream.subscription.surface.rust]
+    /// Opening a subscription needs a tag and a request on the wire,
+    /// both of which are asynchronous — and the surface the
+    /// specification shows is not: `fn events(&self, ..) ->
+    /// Subscription<Event, Closed>`. Deferring the open to the first
+    /// poll is what reconciles them, and it is what a stream does
+    /// anyway: nothing happens until something reads.
+    pub fn opening<F>(open: F) -> Self
+    where
+        F: std::future::Future<Output = Self> + Send + 'static,
+    {
+        use futures::StreamExt;
+        Subscription {
+            source: Source::Open(Box::pin(
+                futures::stream::once(open).flatten(),
+            )),
+        }
+    }
+
+    /// r[impl jetstream.subscription.surface.producer]
+    /// Build the producer's side: a subscription that is handed its
+    /// cancellation when the dispatcher serves it.
+    pub fn served<F, S>(produce: F) -> Self
+    where
+        F: FnOnce(CancellationToken) -> S + Send + 'static,
+        S: futures::Stream<Item = jetstream_error::Result<Item<T, D>>>
+            + Send
+            + 'static,
+    {
+        Subscription {
+            source: Source::Awaiting(Box::new(move |cancel| {
+                Box::pin(produce(cancel))
+            })),
+        }
+    }
+
+    /// r[impl jetstream.subscription.surface.producer]
+    /// The ergonomic producer: a task holding a [`Producer`], which can
+    /// send *and* learn that its subscriber has gone.
+    ///
+    /// `r[jetstream.subscription.detached.state]` is the reason this
+    /// takes a closure rather than a sender: what the closure captures
+    /// is the producer's whole state, and a handler that can only be
+    /// written as "hold this sender" cannot be evicted and resumed.
+    pub fn producing<F, Fut>(capacity: usize, produce: F) -> Self
+    where
+        F: FnOnce(Producer<T, D>) -> Fut + Send + 'static,
+        Fut: std::future::Future<Output = ()> + Send + 'static,
+    {
+        Subscription::served(move |cancel| {
+            let (producer, items) = channel::<T, D>(capacity, cancel);
+            tokio::spawn(produce(producer));
+            futures::StreamExt::map(items, Ok)
+        })
+    }
+
+    /// Take the item sequence, giving the producer its cancellation.
+    ///
+    /// r[impl jetstream.subscription.cancel]
+    /// This is the dispatcher's call, and it is where cancellation
+    /// reaches the work. A subscription that is already a sequence — a
+    /// caller's — ignores the token, which is right: nothing on that
+    /// side produces.
+    pub fn serve(self, cancel: CancellationToken) -> ItemStream<T, D> {
+        match self.source {
+            Source::Open(items) => items,
+            Source::Awaiting(produce) => produce(cancel),
+            Source::Taken => unreachable!("only set while being replaced"),
         }
     }
 
@@ -247,7 +361,7 @@ where
             + 'static,
     {
         Subscription {
-            items: Box::pin(items),
+            source: Source::Open(Box::pin(items)),
         }
     }
 
@@ -271,7 +385,21 @@ impl<T, D> futures::Stream for Subscription<T, D> {
         mut self: std::pin::Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Option<Self::Item>> {
-        self.items.as_mut().poll_next(cx)
+        // A producer's subscription polled without a dispatcher gets a
+        // token nothing cancels. Nothing here can cancel it, so saying
+        // otherwise would be a lie.
+        if let Source::Awaiting(_) = self.source {
+            let Source::Awaiting(produce) =
+                std::mem::replace(&mut self.source, Source::Taken)
+            else {
+                unreachable!("checked immediately above")
+            };
+            self.source = Source::Open(produce(CancellationToken::new()));
+        }
+        match &mut self.source {
+            Source::Open(items) => items.as_mut().poll_next(cx),
+            _ => unreachable!("replaced above"),
+        }
     }
 }
 

--- a/components/jetstream_rpc/src/subscription/tests.rs
+++ b/components/jetstream_rpc/src/subscription/tests.rs
@@ -358,3 +358,51 @@ async fn a_failed_producer_does_not_report_a_normal_ending() {
          {got:?}",
     );
 }
+
+/// r[impl jetstream.subscription.surface.cancellation]
+/// A subscription that opened onto its own producer and is then *served*
+/// must not have that producer cancelled out from under it.
+///
+/// `serve` used to match on `self.source` alone, leaving the rest of the
+/// subscription — including the guard installed by `establish` or a poll
+/// — to drop as it returned. The guard fired immediately, so the stream
+/// handed to the dispatcher was already dead: a handler returning a
+/// pre-established subscription would serve nothing at all.
+#[tokio::test]
+async fn serving_an_opened_subscription_keeps_its_producer() {
+    let alive = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let theirs = alive.clone();
+
+    let mut subscription = Subscription::<u32, ()>::opening(async move {
+        Subscription::producing(4, move |producer| async move {
+            theirs.store(true, std::sync::atomic::Ordering::SeqCst);
+            // Stops only when cancelled, so the test can tell the
+            // difference between "still producing" and "already gone".
+            let mut n = 0u32;
+            while producer.send(n).await.is_ok() {
+                n += 1;
+            }
+            theirs.store(false, std::sync::atomic::Ordering::SeqCst);
+        })
+    });
+
+    // Opening installs the guard on the subscription itself.
+    subscription.establish().await;
+
+    // The dispatcher's call. Its own token is separate; nothing has
+    // cancelled it.
+    let mut items = subscription.serve(CancellationToken::new());
+
+    let first =
+        tokio::time::timeout(std::time::Duration::from_secs(5), items.next())
+            .await
+            .expect("a served producer must still be producing");
+    assert!(
+        matches!(first, Some(Ok(Item::Next(0)))),
+        "expected the producer's first item, got {first:?}",
+    );
+    assert!(
+        alive.load(std::sync::atomic::Ordering::SeqCst),
+        "serving must not cancel the producer it is serving",
+    );
+}

--- a/components/jetstream_rpc/src/subscription/tests.rs
+++ b/components/jetstream_rpc/src/subscription/tests.rs
@@ -276,3 +276,45 @@ async fn merging_says_which_subscription_failed() {
     assert_eq!(failures[0].0, "west", "and the caller can tell which");
     assert!(failures[0].1.contains("the room went away"));
 }
+
+/// r[impl jetstream.subscription.surface.establishment]
+/// Abandoning `establish()` must leave the subscription usable.
+///
+/// It moved the opening future out and left a placeholder behind, so
+/// dropping this future — a timeout, a losing `select!` branch, which is
+/// reachable whenever opening has to wait for a tag — dropped the only
+/// opening future with it. The subscription was then permanently stuck:
+/// a second `establish()` silently did nothing, and the next poll hit an
+/// `unreachable!`.
+///
+/// Tested against an open that is *held* pending on purpose. In process
+/// the open usually completes on its first poll, so a test that merely
+/// raced a short timeout passed with the bug in place — which is how
+/// this nearly went in unverified.
+#[tokio::test]
+async fn an_abandoned_establish_leaves_the_subscription_usable() {
+    use futures::FutureExt;
+
+    let (unblock, blocked) = tokio::sync::oneshot::channel::<()>();
+    let mut subscription: Subscription<u32, ()> =
+        Subscription::opening(async move {
+            let _ = blocked.await;
+            Subscription::from_items(futures::stream::iter(vec![Ok(
+                Item::Next(7),
+            )]))
+        });
+
+    // Abandoned while pending: the open cannot finish yet.
+    assert!(
+        subscription.establish().now_or_never().is_none(),
+        "the open must still be pending for this to test anything"
+    );
+
+    // Now let it finish. The subscription must be exactly as it was.
+    unblock.send(()).unwrap();
+    subscription.establish().await;
+    assert!(
+        matches!(subscription.next().await, Some(Ok(Item::Next(7)))),
+        "an abandoned establishment must not consume the subscription"
+    );
+}

--- a/docs/subscriptions.md
+++ b/docs/subscriptions.md
@@ -99,15 +99,26 @@ typed payload names its method in the payload. One byte, and a protocol
 can have as many subscription methods as it likes.
 
 The method is not `async`, and the subscription opens when it is first
-polled — which is what lets the signature be the plain `fn` it should be
+read — which is what lets the signature be the plain `fn` it should be
 while acquiring a tag and sending a request stay asynchronous. It also
-means *nothing is on the wire until something reads*. Combined with
-`jetstream.lane.no-cross-lane-order` — a subscription on its own lane is
-unordered against a call on another — that makes "subscribe, then act,
-then read" a race. The cursor parameter is the answer: `from` is not
-decoration, it is what makes the sequence well-defined regardless of when
-the request arrived. A producer that ignores it and only forwards live
-events will drop messages, reliably.
+means *nothing is on the wire until something reads*, so "subscribe, then
+act, then read" acts before the subscription exists.
+
+`establish()` says "now":
+
+```rust,ignore
+let mut events = room.events(Context::default(), from);
+events.establish().await;   // the request is on the wire
+```
+
+That is necessary and, across lanes, not sufficient. A subscription on
+its own lane is unordered against a call on another —
+`jetstream.lane.no-cross-lane-order` — and nothing at the RPC layer can
+change that. Which is what the cursor is for: `from` is not decoration,
+it is what makes the sequence well-defined regardless of when the request
+arrived, and a producer that ignores it and only forwards live events
+will drop messages. Reliably, as it turns out: the first version of the
+room in this guide did exactly that, and deadlocked in process.
 
 ## A room
 

--- a/docs/subscriptions.md
+++ b/docs/subscriptions.md
@@ -67,15 +67,54 @@ never reads that lane again — no second request served, and no
 cancellation able to arrive. `server::run` serves the subscriptions in
 flight *and* the requests still arriving, together.
 
+## Declaring one
+
+A subscription is a method on an ordinary `#[service]` trait, marked
+`#[subscription]` and returning `Subscription<Item, Done>`:
+
+```rust,ignore
+#[service]
+pub trait Room {
+    /// Unary. Unchanged by any of this.
+    async fn post(&self, ctx: Context, who: String, body: String)
+        -> Result<u64>;
+
+    /// Streaming: many `Event`s share the request's tag, and the end
+    /// carries a `Closed`.
+    #[subscription]
+    fn events(&self, ctx: Context, from: u64) -> Subscription<Event, Closed>;
+}
+```
+
+The declaration is the protocol's, not the call site's: a dispatcher has
+to route on it before it decodes the payload, and a caller must not be
+able to turn a unary method into a subscription by asking differently.
+
+A streaming method costs no per-method message id. The terminator and the
+cancellation take global ids below `MESSAGE_ID_START`, so `102 + 2 *
+index` is untouched and no existing protocol is renumbered. That has one
+consequence worth knowing: because `RDONE` is a single id, and a decoder
+is handed the type byte without the tag, a terminator that carries a
+typed payload names its method in the payload. One byte, and a protocol
+can have as many subscription methods as it likes.
+
+The method is not `async`, and the subscription opens when it is first
+polled — which is what lets the signature be the plain `fn` it should be
+while acquiring a tag and sending a request stay asynchronous. It also
+means *nothing is on the wire until something reads*. Combined with
+`jetstream.lane.no-cross-lane-order` — a subscription on its own lane is
+unordered against a call on another — that makes "subscribe, then act,
+then read" a race. The cursor parameter is the answer: `from` is not
+decoration, it is what makes the sequence well-defined regardless of when
+the request arrived. A producer that ignores it and only forwards live
+events will drop messages, reliably.
+
 ## A room
 
-The example below is a chat room: one room, many subscribers, no transport
-in the protocol. It runs over a `LocalSession`; the same code runs over
-QUIC, iroh or WebTransport, because what it needs from a session is lanes
-and nothing else.
-
-The protocol is written by hand. `#[service]` will generate all of it —
-this is what it has to generate.
+The example is a chat room: one room, many subscribers, no transport in
+the protocol. It runs over a `LocalSession`; the same code runs over QUIC,
+iroh or WebTransport, because what it needs from a session is lanes and
+nothing else.
 
 ```console
 cargo run --example chat_room
@@ -83,23 +122,26 @@ cargo run --example chat_room
 
 ```text
 joined room-42
-producers alive: 3
 posted #1
   heard: ada says is anyone there?
   heard: ada says is anyone there?
+  heard: ada says is anyone there?
+producers alive: 3
 producers alive after one left: 2
-  ada heard: grace says here
   grace heard: grace says here
-  ada's subscription closed at #2
   grace's subscription closed at #2
+  ada heard: grace says here
+  ada's subscription closed at #2
 producers alive at the end: 0
 ```
 
-Three lines in that output are the three rules above. `posted #1` arrives
+Three lines of that are the three rules above. `posted #1` is answered
 while all three subscriptions are open. `producers alive after one left:
 2` is a dropped subscription stopping the work behind it, not just the
 delivery. And `closed at #2` is a result carried out through a merge and
-still attributable to the subscriber that received it.
+still attributable to the subscriber that received it. (Which of the two
+subscribers the merge reports first is not fixed — there is no ordering
+between distinct subscriptions, and the specification says so.)
 
 ```rust,ignore
 {{#include ../examples/chat_room.rs}}

--- a/examples/chat_room.rs
+++ b/examples/chat_room.rs
@@ -240,16 +240,22 @@ async fn main() -> Result<()> {
     // Two subscribers, and a third that leaves early.
     let mut ada = on.lane().await?.events(Context::default(), 0);
     let mut grace = on.lane().await?.events(Context::default(), 0);
-    let leaving = on.lane().await?.events(Context::default(), 0);
+    let mut leaving = on.lane().await?.events(Context::default(), 0);
 
-    // Nothing has opened yet: a subscription opens when it is first
-    // polled. Reading one event from each is what puts them on the wire.
+    // A subscription opens when it is first read, so say "now" instead.
+    // Necessary, and *not* sufficient: each of these is on its own lane
+    // and the post below is on another, and there is no ordering
+    // between lanes. That is what `from` is for, and why the room keeps
+    // a log — the two together are what make this deterministic.
+    for who in [&mut ada, &mut grace, &mut leaving] {
+        who.establish().await;
+    }
+
     let seq = poster
         .post(Context::default(), "ada".into(), "is anyone there?".into())
         .await?;
     println!("posted #{seq}");
 
-    let mut leaving = leaving;
     for who in [&mut ada, &mut grace, &mut leaving] {
         match who.next().await.expect("an event")? {
             Item::Next(event) => {

--- a/examples/chat_room.rs
+++ b/examples/chat_room.rs
@@ -16,43 +16,22 @@
 //! * a subscription does not take the lane it is served on, so `post`
 //!   still works while every subscriber is listening.
 //!
-//! The protocol here is written by hand. `#[service]` will generate all
-//! of it — this is what it has to generate.
-//!
 //! ```console
 //! cargo run --example chat_room
 //! ```
 
-use std::{
-    io,
-    sync::{
-        atomic::{AtomicU64, AtomicUsize, Ordering::SeqCst},
-        Arc,
-    },
+use std::sync::{
+    atomic::{AtomicU64, AtomicUsize, Ordering::SeqCst},
+    Arc,
 };
 
 use futures::StreamExt;
 use jetstream::prelude::*;
-use jetstream_rpc::{
-    server::ResponseStream,
-    session::{LocalSession, Session},
-    subscription::{
-        self, CancellationToken, Rcancel, Tcancel, Terminator, RCANCEL, RDONE,
-        TCANCEL,
-    },
-    Mux,
-};
+use jetstream_macros::service;
+use jetstream_rpc::session::{LocalSession, Session};
 use tokio::sync::broadcast;
 
-// ---------------------------------------------------------------------------
-// The wire types. Two methods, so two request ids in the per-method
-// space: 102 + 2 * index. The terminator and the cancellation take the
-// global ids, which is what keeps that arithmetic intact.
-
-const TPOST: u8 = 102;
-const RPOST: u8 = 103;
-const TEVENTS: u8 = 104;
-const REVENT: u8 = 105;
+use crate::room_protocol::{RoomChannel, RoomService};
 
 #[derive(Debug, Clone, JetStreamWireFormat)]
 pub struct Event {
@@ -62,251 +41,119 @@ pub struct Event {
 }
 
 /// What the room says when a subscription ends normally. This is the
-/// value that has nowhere to live in a plain `Stream`.
+/// value a plain `Stream` has nowhere to put.
 #[derive(Debug, Clone, JetStreamWireFormat)]
 pub struct Closed {
     pub last_seq: u64,
 }
 
-#[derive(Debug, Clone, JetStreamWireFormat)]
-pub struct Post {
-    pub who: String,
-    pub body: String,
+#[service(uses(super::{Closed, Event}))]
+pub trait Room {
+    /// Unary, and unchanged by any of this.
+    async fn post(
+        &self,
+        ctx: Context,
+        who: String,
+        body: String,
+    ) -> Result<u64>;
+
+    /// Streaming: every event from `from` onwards, until the subscriber
+    /// leaves or the room closes.
+    #[subscription]
+    fn events(&self, ctx: Context, from: u64) -> Subscription<Event, Closed>;
 }
-
-#[derive(Debug)]
-pub enum Ask {
-    Post(Post),
-    Events(u64),
-    Cancel(Tcancel),
-}
-
-#[derive(Debug)]
-pub enum Say {
-    Posted(u64),
-    Event(Event),
-    Done(Terminator<Closed>),
-    Ack(Rcancel),
-}
-
-impl Framer for Ask {
-    fn message_type(&self) -> u8 {
-        match self {
-            Ask::Post(_) => TPOST,
-            Ask::Events(_) => TEVENTS,
-            Ask::Cancel(_) => TCANCEL,
-        }
-    }
-
-    fn byte_size(&self) -> u32 {
-        match self {
-            Ask::Post(p) => p.byte_size(),
-            Ask::Events(f) => f.byte_size(),
-            Ask::Cancel(c) => c.byte_size(),
-        }
-    }
-
-    fn encode<W: io::Write>(&self, w: &mut W) -> io::Result<()> {
-        match self {
-            Ask::Post(p) => p.encode(w),
-            Ask::Events(f) => f.encode(w),
-            Ask::Cancel(c) => c.encode(w),
-        }
-    }
-
-    fn decode<R: io::Read>(r: &mut R, ty: u8) -> io::Result<Self> {
-        match ty {
-            TPOST => Ok(Ask::Post(WireFormat::decode(r)?)),
-            TEVENTS => Ok(Ask::Events(WireFormat::decode(r)?)),
-            TCANCEL => Ok(Ask::Cancel(WireFormat::decode(r)?)),
-            other => Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!("unknown request type {other}"),
-            )),
-        }
-    }
-}
-
-impl Framer for Say {
-    fn message_type(&self) -> u8 {
-        match self {
-            Say::Posted(_) => RPOST,
-            Say::Event(_) => REVENT,
-            Say::Done(_) => RDONE,
-            Say::Ack(_) => RCANCEL,
-        }
-    }
-
-    fn byte_size(&self) -> u32 {
-        match self {
-            Say::Posted(s) => s.byte_size(),
-            Say::Event(e) => e.byte_size(),
-            Say::Done(d) => d.byte_size(),
-            Say::Ack(a) => a.byte_size(),
-        }
-    }
-
-    fn encode<W: io::Write>(&self, w: &mut W) -> io::Result<()> {
-        match self {
-            Say::Posted(s) => s.encode(w),
-            Say::Event(e) => e.encode(w),
-            Say::Done(d) => d.encode(w),
-            Say::Ack(a) => a.encode(w),
-        }
-    }
-
-    fn decode<R: io::Read>(r: &mut R, ty: u8) -> io::Result<Self> {
-        match ty {
-            RPOST => Ok(Say::Posted(WireFormat::decode(r)?)),
-            REVENT => Ok(Say::Event(WireFormat::decode(r)?)),
-            // The terminator's payload names its method, because `RDONE`
-            // is one global id and a decoder never sees the tag. With
-            // one subscription method there is nothing to tell apart
-            // yet; with two there would be.
-            RDONE => Ok(Say::Done(WireFormat::decode(r)?)),
-            RCANCEL => Ok(Say::Ack(WireFormat::decode(r)?)),
-            other => Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!("unknown response type {other}"),
-            )),
-        }
-    }
-}
-
-#[derive(Clone)]
-pub struct Room;
-
-impl Protocol for Room {
-    type Error = Error;
-    type Request = Ask;
-    type Response = Say;
-
-    const NAME: &'static str = "room";
-    const VERSION: &'static str = "rs.jetstream.proto/room/0.1.0";
-
-    fn tcancel(oldtag: u16, binding: u64) -> Option<Ask> {
-        Some(Ask::Cancel(Tcancel { oldtag, binding }))
-    }
-}
-
-// ---------------------------------------------------------------------------
-// The service.
 
 #[derive(Clone)]
 struct ChatRoom {
     events: broadcast::Sender<Event>,
+    /// Everything said so far.
+    ///
+    /// r[impl jetstream.subscription.surface.producer]
+    /// A producer driven by a *cursor*, not only by a live sender. This
+    /// is not decoration: a subscription opens on its own lane, and
+    /// `jetstream.lane.no-cross-lane-order` means it is unordered
+    /// against a `post` on another one. Without a log to replay from,
+    /// "subscribe, then post, then read" is a race that the in-process
+    /// session loses reliably — which is how this example found it.
+    log: Arc<std::sync::Mutex<Vec<Event>>>,
     seq: Arc<AtomicU64>,
     /// Cancelled when the room itself closes, which is the *other* way a
     /// subscription ends — and the one that carries a result.
-    closing: CancellationToken,
+    closing: subscription::CancellationToken,
     /// How many producers are alive. The example prints it to show that
     /// cancelling a subscription stops the work, rather than leaving it
     /// running with nowhere to deliver.
     producers: Arc<AtomicUsize>,
 }
 
-impl Protocol for ChatRoom {
-    type Error = Error;
-    type Request = Ask;
-    type Response = Say;
-
-    const NAME: &'static str = Room::NAME;
-    const VERSION: &'static str = Room::VERSION;
-
-    fn tcancel(oldtag: u16, binding: u64) -> Option<Ask> {
-        Room::tcancel(oldtag, binding)
-    }
-}
-
-impl Server for ChatRoom {
-    fn is_streaming(message_type: u8) -> bool {
-        message_type == TEVENTS
-    }
-
-    fn cancel_target(frame: &Frame<Ask>) -> Option<u16> {
-        match &frame.msg {
-            Ask::Cancel(c) => Some(c.oldtag),
-            _ => None,
-        }
-    }
-
-    fn cancel_ack(oldtag: u16) -> Option<Say> {
-        Some(Say::Ack(Rcancel { oldtag }))
-    }
-
-    fn cancelled_terminator(method: u8) -> Option<Say> {
-        // One streaming method, so `method` can only be `TEVENTS` — but
-        // the terminator names it, so a second one would decode
-        // correctly without touching this.
-        Some(Say::Done(Terminator {
-            method,
-            value: Closed { last_seq: 0 },
-        }))
-    }
-
-    async fn rpc(
-        &mut self,
+impl Room for ChatRoom {
+    async fn post(
+        &self,
         _ctx: Context,
-        frame: Frame<Ask>,
-    ) -> std::result::Result<Frame<Say>, Error> {
-        match frame.msg {
-            Ask::Post(post) => {
-                let seq = self.seq.fetch_add(1, SeqCst) + 1;
-                // A subscriber that has gone is not an error here: the
-                // room does not know or care who is listening.
-                let _ = self.events.send(Event {
-                    seq,
-                    who: post.who,
-                    body: post.body,
-                });
-                Ok(Frame {
-                    tag: frame.tag,
-                    msg: Say::Posted(seq),
-                })
-            }
-            other => Err(Error::new(format!("not a unary method: {other:?}"))),
-        }
+        who: String,
+        body: String,
+    ) -> Result<u64> {
+        let seq = self.seq.fetch_add(1, SeqCst) + 1;
+        let event = Event { seq, who, body };
+        self.log.lock().unwrap().push(event.clone());
+        // Nobody listening is not an error: the room does not know or
+        // care who is.
+        let _ = self.events.send(event);
+        Ok(seq)
     }
 
-    async fn rpc_stream(
-        &mut self,
-        _ctx: Context,
-        frame: Frame<Ask>,
-        cancel: CancellationToken,
-    ) -> ResponseStream<Self> {
-        let tag = frame.tag;
-        let from = match frame.msg {
-            Ask::Events(from) => from,
-            _ => 0,
-        };
-
-        // The producer's end. It can send *and* learn that its
-        // subscriber has gone — the half a bare `Sender` cannot do.
-        let (producer, items) =
-            subscription::channel::<Event, Closed>(64, cancel);
-        let stop = producer.cancellation();
+    fn events(&self, _ctx: Context, from: u64) -> Subscription<Event, Closed> {
+        // Subscribe to the live feed *before* reading the log, so
+        // nothing said in between is missed. Anything the replay
+        // already covered is skipped by sequence below.
         let mut feed = self.events.subscribe();
+        let backlog: Vec<Event> = self
+            .log
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|e| e.seq >= from)
+            .cloned()
+            .collect();
         let seq = self.seq.clone();
         let closing = self.closing.clone();
         let producers = self.producers.clone();
-        producers.fetch_add(1, SeqCst);
 
-        tokio::spawn(async move {
+        // The producer can send *and* learn that its subscriber has
+        // gone — the half a bare `Sender` cannot do.
+        Subscription::producing(64, move |producer| async move {
+            producers.fetch_add(1, SeqCst);
+            let mut sent_through = from.saturating_sub(1);
+            for event in backlog {
+                sent_through = event.seq;
+                if producer.send(event).await.is_err() {
+                    producers.fetch_sub(1, SeqCst);
+                    return;
+                }
+            }
             let ending = loop {
                 tokio::select! {
-                    // The subscriber went away. Stop the work; there is
-                    // no result to report to someone who is not there.
-                    _ = stop.cancelled() => break None,
-                    // The room closed. That *is* a result.
-                    _ = closing.cancelled() => {
-                        break Some(Closed { last_seq: seq.load(SeqCst) });
-                    }
+                    // Biased, and in this order, because
+                    // r[jetstream.subscription.cancel] puts the
+                    // terminator *after* every item already emitted.
+                    // Left to chance, a subscriber can miss the last
+                    // message because the room closed in the same
+                    // instant — which is what happened before this line
+                    // was here.
+                    biased;
+
+                    // The subscriber left. Stop the work; there is no
+                    // result to report to someone who is not there, and
+                    // nothing to drain for them either.
+                    _ = producer.cancelled() => break None,
                     got = feed.recv() => match got {
                         Ok(event) => {
-                            if event.seq >= from
-                                && producer.send(event).await.is_err()
-                            {
-                                break None;
+                            // Skip what the replay already covered.
+                            if event.seq > sent_through {
+                                sent_through = event.seq;
+                                if producer.send(event).await.is_err() {
+                                    break None;
+                                }
                             }
                         }
                         Err(broadcast::error::RecvError::Lagged(_)) => continue,
@@ -314,142 +161,52 @@ impl Server for ChatRoom {
                             break Some(Closed { last_seq: seq.load(SeqCst) })
                         }
                     },
+                    // The room closed. That *is* a result — and it is
+                    // reached only once the feed has nothing left.
+                    _ = closing.cancelled() => {
+                        break Some(Closed { last_seq: seq.load(SeqCst) });
+                    }
                 }
             };
             if let Some(closed) = ending {
                 producer.finish(closed).await;
             }
             producers.fetch_sub(1, SeqCst);
-        });
-
-        items.into_frames::<Self, _>(tag, move |item| match item {
-            subscription::Item::Next(event) => Say::Event(event),
-            subscription::Item::Done(closed) => Say::Done(Terminator {
-                method: TEVENTS,
-                value: closed,
-            }),
         })
     }
 }
 
-// ---------------------------------------------------------------------------
-// The client.
-
-/// Built over the **session**, not over a lane — a channel handed one
+/// Built over the **session**, not over a lane: a channel handed one
 /// transport can only tag-multiplex, which would make the caller's
 /// construction the realisation choice.
-struct RoomChannel {
-    session: LocalSession<Room>,
-    endpoint: Endpoint,
-    /// Shared, so a subscription can be opened on the same lane the
-    /// unary calls use — which is the arrangement that actually
-    /// exercises `jetstream.subscription.dispatch.concurrent`.
-    unary: std::sync::Arc<Mux<Room>>,
+///
+/// On this session — `LaneSupport::Many` — every subscription gets a
+/// lane of its own, for independent flow control. On a session with one
+/// lane the same code tag-multiplexes, and the caller's types do not
+/// change. That is `jetstream.subscription.realisation.opaque`.
+struct RoomOn {
+    session: LocalSession<RoomChannel>,
+    endpoint: subscription::Endpoint,
 }
 
-impl RoomChannel {
-    async fn over(
-        session: LocalSession<Room>,
-        endpoint: Endpoint,
-    ) -> std::result::Result<Self, Box<dyn std::error::Error>> {
-        let lane = Session::<Room>::open_lane(&session).await?;
-        Ok(RoomChannel {
-            session,
-            endpoint,
-            unary: std::sync::Arc::new(Mux::new(64, Box::new(lane))),
-        })
-    }
-
-    async fn post(
-        &self,
-        who: &str,
-        body: &str,
-    ) -> std::result::Result<u64, Error> {
-        let answer = self
-            .unary
-            .rpc(
-                Context::default(),
-                Ask::Post(Post {
-                    who: who.to_string(),
-                    body: body.to_string(),
-                }),
-            )
+impl RoomOn {
+    async fn lane(&self) -> Result<RoomChannel> {
+        let lane = Session::<RoomChannel>::open_lane(&self.session)
             .await
-            .await?;
-        match answer.msg {
-            Say::Posted(seq) => Ok(seq),
-            other => Err(Error::new(format!("unexpected answer: {other:?}"))),
-        }
-    }
-
-    /// A subscription on a lane of its own, because this session has
-    /// many — the choice `Capability::ManyLanes` licenses and that the
-    /// caller never sees. On a session with one lane this would be a tag
-    /// on the shared one, and the type below would be the same.
-    async fn events(
-        &self,
-        from: u64,
-    ) -> std::result::Result<
-        Subscription<Event, Closed>,
-        Box<dyn std::error::Error>,
-    > {
-        let lane = Session::<Room>::open_lane(&self.session).await?;
-        Ok(Self::events_on(
-            std::sync::Arc::new(Mux::<Room>::new(64, Box::new(lane))),
-            from,
-        )
-        .await)
-    }
-
-    /// A subscription on the multiplexer the caller already holds — that
-    /// is, **sharing a lane with its other calls**.
-    ///
-    /// This exists because the example was not demonstrating what it
-    /// claimed. Every subscription opened its own lane and `post` used
-    /// another, so `posted #1` proved only that a second lane works:
-    /// reverting the dispatcher fix would have printed it just the same,
-    /// with each subscription lane occupied forever and the unary lane
-    /// answering normally. Sharing a lane is the case
-    /// `jetstream.subscription.dispatch.concurrent` is actually about.
-    /// A subscription sharing the lane this channel's `post` uses.
-    async fn events_here(&self, from: u64) -> Subscription<Event, Closed> {
-        Self::events_on(self.unary.clone(), from).await
-    }
-
-    async fn events_on(
-        mux: std::sync::Arc<Mux<Room>>,
-        from: u64,
-    ) -> Subscription<Event, Closed> {
-        let frames = mux
-            .rpc_stream(Context::default(), Ask::Events(from), 64)
-            .await;
-        Subscription::from_frames(frames, move |frame| {
-            // The lane's multiplexer has to outlive the subscription
-            // reading through it, so it rides along in this closure.
-            let _ = &mux;
-            match frame.msg {
-                Say::Event(event) => Ok(Item::Next(event)),
-                Say::Done(done) => Ok(Item::Done(done.value)),
-                other => Err(Error::new(format!("unexpected item: {other:?}"))),
-            }
-        })
-    }
-
-    fn endpoint(&self) -> &Endpoint {
-        &self.endpoint
+            .map_err(|e| Error::new(e.to_string()))?;
+        Ok(RoomChannel::new(64, Box::new(lane)))
     }
 }
-
-// ---------------------------------------------------------------------------
 
 #[tokio::main]
-async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
-    let pair = LocalSession::<Room>::pair();
+async fn main() -> Result<()> {
+    let pair = LocalSession::<RoomChannel>::pair();
 
     let room = ChatRoom {
         events: broadcast::channel(256).0,
+        log: Arc::new(std::sync::Mutex::new(Vec::new())),
         seq: Arc::new(AtomicU64::new(0)),
-        closing: CancellationToken::new(),
+        closing: subscription::CancellationToken::new(),
         producers: Arc::new(AtomicUsize::new(0)),
     };
     let producers = room.producers.clone();
@@ -460,43 +217,40 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     let serving = {
         let server = pair.server.clone();
         tokio::spawn(async move {
-            while let Ok(lane) = Session::<Room>::accept_lane(&server).await {
-                let mut room = room.clone();
+            while let Ok(lane) =
+                Session::<RoomChannel>::accept_lane(&server).await
+            {
+                let inner = room.clone();
                 tokio::spawn(async move {
-                    let _ = jetstream_rpc::server::run(&mut room, lane).await;
+                    let mut service = RoomService { inner };
+                    let _ =
+                        jetstream_rpc::server::run(&mut service, lane).await;
                 });
             }
         })
     };
 
-    let channel =
-        RoomChannel::over(pair.client.clone(), Endpoint::from("room-42"))
-            .await?;
-    println!(
-        "joined {}",
-        String::from_utf8_lossy(channel.endpoint().as_bytes())
-    );
+    let on = RoomOn {
+        session: pair.client.clone(),
+        endpoint: subscription::Endpoint::from("room-42"),
+    };
+    println!("joined {}", String::from_utf8_lossy(on.endpoint.as_bytes()));
 
-    // Ada subscribes on the **same lane** the posts below go out on.
-    // With each subscription on its own lane, `posted #1` would print
-    // even with the dispatcher serving a subscription to exhaustion —
-    // the subscription lane would hang and the unary lane would answer
-    // regardless, which is what made the earlier version of this example
-    // decorative on its central claim.
-    let mut ada = channel.events_here(0).await;
-    // Grace gets a lane of her own, which is the other realisation.
-    let mut grace = channel.events(0).await?;
-    let leaving = channel.events(0).await?;
-    settle().await;
-    println!("producers alive: {}", producers.load(SeqCst));
+    let poster = on.lane().await?;
+    // Two subscribers, and a third that leaves early.
+    let mut ada = on.lane().await?.events(Context::default(), 0);
+    let mut grace = on.lane().await?.events(Context::default(), 0);
+    let leaving = on.lane().await?.events(Context::default(), 0);
 
-    // A subscription is one call among the lane's others. This used to
-    // hang: the dispatcher served a subscription by consuming it, and
-    // never read the lane again.
-    let seq = channel.post("ada", "is anyone there?").await?;
+    // Nothing has opened yet: a subscription opens when it is first
+    // polled. Reading one event from each is what puts them on the wire.
+    let seq = poster
+        .post(Context::default(), "ada".into(), "is anyone there?".into())
+        .await?;
     println!("posted #{seq}");
 
-    for who in [&mut ada, &mut grace] {
+    let mut leaving = leaving;
+    for who in [&mut ada, &mut grace, &mut leaving] {
         match who.next().await.expect("an event")? {
             Item::Next(event) => {
                 println!("  heard: {} says {}", event.who, event.body)
@@ -504,6 +258,8 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
             Item::Done(_) => panic!("not yet"),
         }
     }
+    settle().await;
+    println!("producers alive: {}", producers.load(SeqCst));
 
     // Dropping a subscription cancels it, and cancelling reaches the
     // work: the producer behind it stops, rather than carrying on with
@@ -512,9 +268,12 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     settle().await;
     println!("producers alive after one left: {}", producers.load(SeqCst));
 
-    // Closing the room ends every subscription with a *result*. This is
-    // the value a plain `Stream` has nowhere to put.
-    channel.post("grace", "here").await?;
+    // A subscription is one call among the lane's others, so posting
+    // works while every subscriber is listening.
+    poster
+        .post(Context::default(), "grace".into(), "here".into())
+        .await?;
+    // Closing the room ends every subscription with a *result*.
     closing.cancel();
 
     // Fan-in: merged, and still able to say which subscription ended and
@@ -522,19 +281,16 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     // event and no ending at all.
     let mut merged = subscription::merge([("ada", ada), ("grace", grace)]);
     while let Some(next) = merged.next().await {
-        match next {
-            (who, Ok(Item::Next(event))) => {
+        match next? {
+            (who, Item::Next(event)) => {
                 println!("  {who} heard: {} says {}", event.who, event.body)
             }
-            (who, Ok(Item::Done(closed))) => {
+            (who, Item::Done(closed)) => {
                 println!(
                     "  {who}'s subscription closed at #{}",
                     closed.last_seq
                 )
             }
-            // The key survives a failure too, so a fan-in can say which
-            // room went away rather than only that one did.
-            (who, Err(e)) => println!("  {who} failed: {e}"),
         }
     }
 

--- a/examples/chat_room.rs
+++ b/examples/chat_room.rs
@@ -237,8 +237,15 @@ async fn main() -> Result<()> {
     println!("joined {}", String::from_utf8_lossy(on.endpoint.as_bytes()));
 
     let poster = on.lane().await?;
-    // Two subscribers, and a third that leaves early.
-    let mut ada = on.lane().await?.events(Context::default(), 0);
+    // Ada subscribes on the **same lane** the posts below go out on.
+    // With every subscription on a lane of its own, `posted #1` would
+    // print even with the dispatcher serving a subscription to
+    // exhaustion — the subscription lanes would hang and the unary lane
+    // would answer regardless. That is what made an earlier version of
+    // this example decorative on its central claim.
+    let mut ada = poster.events(Context::default(), 0);
+    // Grace and the one who leaves get lanes of their own, which is the
+    // other realisation and equally invisible in the types.
     let mut grace = on.lane().await?.events(Context::default(), 0);
     let mut leaving = on.lane().await?.events(Context::default(), 0);
 
@@ -287,16 +294,19 @@ async fn main() -> Result<()> {
     // event and no ending at all.
     let mut merged = subscription::merge([("ada", ada), ("grace", grace)]);
     while let Some(next) = merged.next().await {
-        match next? {
-            (who, Item::Next(event)) => {
+        match next {
+            (who, Ok(Item::Next(event))) => {
                 println!("  {who} heard: {} says {}", event.who, event.body)
             }
-            (who, Item::Done(closed)) => {
+            (who, Ok(Item::Done(closed))) => {
                 println!(
                     "  {who}'s subscription closed at #{}",
                     closed.last_seq
                 )
             }
+            // The key survives a failure too, so a fan-in can say which
+            // room went away rather than only that one did.
+            (who, Err(e)) => println!("  {who} failed: {e}"),
         }
     }
 

--- a/tests/subscriptions.rs
+++ b/tests/subscriptions.rs
@@ -1,0 +1,288 @@
+//! A generated subscription, end to end over a session.
+//!
+//! The example proves the shape runs; these prove the individual
+//! promises, one at a time, and fail loudly rather than hanging.
+
+use std::{
+    sync::{
+        atomic::{AtomicUsize, Ordering::SeqCst},
+        Arc,
+    },
+    time::Duration,
+};
+
+use futures::StreamExt;
+use jetstream::prelude::*;
+use jetstream_rpc::session::{LocalSession, Session};
+use tokio::sync::broadcast;
+
+use crate::counter_protocol::{CounterChannel, CounterService};
+
+#[derive(Debug, Clone, PartialEq, Eq, JetStreamWireFormat)]
+pub struct Tick(pub u64);
+
+#[derive(Debug, Clone, PartialEq, Eq, JetStreamWireFormat)]
+pub struct Total(pub u64);
+
+#[service(uses(super::{Tick, Total}))]
+pub trait Counter {
+    /// Unary, and it must keep working while a subscription is open.
+    async fn bump(&self, ctx: Context) -> Result<u64>;
+
+    /// Streaming: every bump from now on, until the counter stops.
+    #[subscription]
+    fn ticks(&self, ctx: Context) -> Subscription<Tick, Total>;
+}
+
+#[derive(Clone)]
+struct Counting {
+    ticks: broadcast::Sender<Tick>,
+    stop: subscription::CancellationToken,
+    /// How many producers are alive: the only way to see that
+    /// cancellation reached the work rather than only the delivery.
+    producers: Arc<AtomicUsize>,
+    seen: Arc<AtomicUsize>,
+}
+
+impl Counter for Counting {
+    async fn bump(&self, _ctx: Context) -> Result<u64> {
+        let n = self.seen.fetch_add(1, SeqCst) as u64 + 1;
+        let _ = self.ticks.send(Tick(n));
+        Ok(n)
+    }
+
+    fn ticks(&self, _ctx: Context) -> Subscription<Tick, Total> {
+        let mut feed = self.ticks.subscribe();
+        let stop = self.stop.clone();
+        let seen = self.seen.clone();
+        let producers = self.producers.clone();
+        Subscription::producing(16, move |producer| async move {
+            producers.fetch_add(1, SeqCst);
+            let ending = loop {
+                tokio::select! {
+                    biased;
+                    _ = producer.cancelled() => break None,
+                    got = feed.recv() => match got {
+                        Ok(tick) => {
+                            if producer.send(tick).await.is_err() {
+                                break None;
+                            }
+                        }
+                        Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                        Err(_) => break Some(Total(seen.load(SeqCst) as u64)),
+                    },
+                    _ = stop.cancelled() => {
+                        break Some(Total(seen.load(SeqCst) as u64))
+                    }
+                }
+            };
+            if let Some(total) = ending {
+                producer.finish(total).await;
+            }
+            producers.fetch_sub(1, SeqCst);
+        })
+    }
+}
+
+struct Wired {
+    session: LocalSession<CounterChannel>,
+    producers: Arc<AtomicUsize>,
+    stop: subscription::CancellationToken,
+}
+
+impl Wired {
+    fn new() -> Self {
+        let pair = LocalSession::<CounterChannel>::pair();
+        let counting = Counting {
+            ticks: broadcast::channel(64).0,
+            stop: subscription::CancellationToken::new(),
+            producers: Default::default(),
+            seen: Default::default(),
+        };
+        let producers = counting.producers.clone();
+        let stop = counting.stop.clone();
+        let server = pair.server.clone();
+        tokio::spawn(async move {
+            while let Ok(lane) =
+                Session::<CounterChannel>::accept_lane(&server).await
+            {
+                let inner = counting.clone();
+                tokio::spawn(async move {
+                    let mut service = CounterService { inner };
+                    let _ =
+                        jetstream_rpc::server::run(&mut service, lane).await;
+                });
+            }
+        });
+        Wired {
+            session: pair.client,
+            producers,
+            stop,
+        }
+    }
+
+    async fn lane(&self) -> CounterChannel {
+        let lane = Session::<CounterChannel>::open_lane(&self.session)
+            .await
+            .expect("the session is open");
+        CounterChannel::new(16, Box::new(lane))
+    }
+}
+
+async fn settle() {
+    tokio::time::sleep(Duration::from_millis(50)).await;
+}
+
+/// Wait for a condition rather than sleeping and hoping.
+async fn until(what: &str, mut cond: impl FnMut() -> bool) {
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    while !cond() {
+        assert!(std::time::Instant::now() < deadline, "timed out: {what}");
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
+/// r[verify jetstream.subscription.overview]
+/// One request, many responses.
+#[tokio::test]
+async fn a_generated_subscription_delivers_many_items() {
+    let wired = Wired::new();
+    let mut ticks = wired.lane().await.ticks(Context::default());
+    let bumper = wired.lane().await;
+
+    // A subscription opens when it is first polled, so nothing is on the
+    // wire yet — hence the settle after the first read below.
+    let first = tokio::spawn(async move {
+        let mut got = Vec::new();
+        while let Some(item) = ticks.next().await {
+            match item.unwrap() {
+                Item::Next(Tick(n)) => {
+                    got.push(n);
+                    if got.len() == 3 {
+                        break;
+                    }
+                }
+                Item::Done(_) => break,
+            }
+        }
+        got
+    });
+    settle().await;
+
+    for _ in 0..3 {
+        bumper.bump(Context::default()).await.unwrap();
+    }
+
+    let got = tokio::time::timeout(Duration::from_secs(5), first)
+        .await
+        .expect("three items must arrive")
+        .unwrap();
+    assert_eq!(got, vec![1, 2, 3]);
+}
+
+/// r[verify jetstream.subscription.dispatch.concurrent]
+/// A subscription is one call among the lane's others. Both go on the
+/// *same* lane here, so a dispatcher that served the subscription by
+/// consuming it would never answer the bump.
+#[tokio::test]
+async fn a_unary_call_works_on_a_lane_serving_a_subscription() {
+    let wired = Wired::new();
+    let channel = wired.lane().await;
+    let mut ticks = channel.ticks(Context::default());
+
+    // Open it: nothing reaches the service until the stream is polled.
+    let opened = tokio::spawn(async move { ticks.next().await });
+    settle().await;
+
+    let n = tokio::time::timeout(
+        Duration::from_secs(5),
+        channel.bump(Context::default()),
+    )
+    .await
+    .expect("the lane must still answer while a subscription is open")
+    .unwrap();
+    assert_eq!(n, 1);
+    opened.abort();
+}
+
+/// r[verify jetstream.subscription.cancel]
+/// r[verify jetstream.subscription.surface.cancellation]
+/// Dropping the subscription must stop the *producer*, not merely stop
+/// the delivery.
+#[tokio::test]
+async fn dropping_a_generated_subscription_stops_the_producer() {
+    let wired = Wired::new();
+    let mut ticks = wired.lane().await.ticks(Context::default());
+    let bumper = wired.lane().await;
+
+    let reading = tokio::spawn(async move {
+        let item = ticks.next().await;
+        // Hold it open until told otherwise.
+        (item, ticks)
+    });
+    settle().await;
+    bumper.bump(Context::default()).await.unwrap();
+
+    let (first, held) = tokio::time::timeout(Duration::from_secs(5), reading)
+        .await
+        .expect("the first item must arrive")
+        .unwrap();
+    assert!(matches!(first, Some(Ok(Item::Next(Tick(1))))));
+    until("the producer must start", || {
+        wired.producers.load(SeqCst) == 1
+    })
+    .await;
+
+    drop(held);
+    until("dropping the subscription must stop the producer", || {
+        wired.producers.load(SeqCst) == 0
+    })
+    .await;
+}
+
+/// r[verify jetstream.subscription.surface.terminal-value]
+/// r[verify jetstream.subscription.surface.composition]
+/// The end is a value, it carries a result, and a merge keeps both the
+/// result and which subscription it came from.
+#[tokio::test]
+async fn merging_keeps_the_result_and_says_whose() {
+    let wired = Wired::new();
+    let one = wired.lane().await.ticks(Context::default());
+    let two = wired.lane().await.ticks(Context::default());
+    let bumper = wired.lane().await;
+
+    let merged = subscription::merge([("one", one), ("two", two)]);
+    let collecting = tokio::spawn(async move {
+        let mut merged = merged;
+        let mut ends = Vec::new();
+        while let Some(next) = merged.next().await {
+            if let (who, Item::Done(Total(total))) = next.unwrap() {
+                ends.push((who, total));
+            }
+        }
+        ends
+    });
+    settle().await;
+
+    bumper.bump(Context::default()).await.unwrap();
+    bumper.bump(Context::default()).await.unwrap();
+    settle().await;
+    wired.stop.cancel();
+
+    let mut ends = tokio::time::timeout(Duration::from_secs(5), collecting)
+        .await
+        .expect("both subscriptions must end")
+        .unwrap();
+    ends.sort();
+    assert_eq!(ends, vec![("one", 2), ("two", 2)]);
+}
+
+/// r[verify jetstream.subscription.compat.existing-clients]
+/// The unary method is untouched by any of this.
+#[tokio::test]
+async fn unary_methods_are_unchanged() {
+    let wired = Wired::new();
+    let channel = wired.lane().await;
+    assert_eq!(channel.bump(Context::default()).await.unwrap(), 1);
+    assert_eq!(channel.bump(Context::default()).await.unwrap(), 2);
+}

--- a/tests/subscriptions.rs
+++ b/tests/subscriptions.rs
@@ -456,6 +456,48 @@ async fn an_in_process_producer_is_cancelled_when_dropped() {
     .await;
 }
 
+/// r[verify jetstream.subscription.surface.cancellation]
+/// The same promise, one step removed: a producer reached through
+/// `opening` rather than polled directly.
+///
+/// Opening runs inside a boxed future that cannot reach the subscription
+/// the caller holds, so the token it made for the producer had no owner
+/// — dropping the subscription woke nothing, and the spawned `producing`
+/// task went on sending to a receiver that was gone. The guard now
+/// travels out of the opening future to the subscription itself.
+#[tokio::test]
+async fn a_producer_opened_into_is_cancelled_when_dropped() {
+    let counting = Counting {
+        ticks: broadcast::channel(64).0,
+        stop: subscription::CancellationToken::new(),
+        producers: Default::default(),
+        seen: Default::default(),
+    };
+    let producers = counting.producers.clone();
+
+    // The shape `opening` exists for: a plain `fn` handing back a
+    // subscription whose real work is deferred, wrapping a producer.
+    // A clone goes into the opener so `counting` — and with it the
+    // broadcast sender the producer is reading — outlives the future;
+    // otherwise the producer ends because its feed closed, which is not
+    // what this test is about.
+    let opener = counting.clone();
+    let mut ticks =
+        Subscription::opening(async move { opener.ticks(Context::default()) });
+
+    // Open it, so the producer starts. Without opening first there is
+    // nothing to leak.
+    ticks.establish().await;
+    until("the producer must start", || producers.load(SeqCst) == 1).await;
+
+    drop(ticks);
+    until(
+        "dropping an opened subscription must stop its producer too",
+        || producers.load(SeqCst) == 0,
+    )
+    .await;
+}
+
 // ---------------------------------------------------------------------
 // A subscription whose producer fails partway through.
 // ---------------------------------------------------------------------

--- a/tests/subscriptions.rs
+++ b/tests/subscriptions.rs
@@ -11,7 +11,7 @@ use std::{
     time::Duration,
 };
 
-use futures::StreamExt;
+use futures::{FutureExt, StreamExt};
 use jetstream::prelude::*;
 use jetstream_rpc::session::{LocalSession, Session};
 use tokio::sync::broadcast;
@@ -256,8 +256,10 @@ async fn merging_keeps_the_result_and_says_whose() {
         let mut merged = merged;
         let mut ends = Vec::new();
         while let Some(next) = merged.next().await {
-            if let (who, Item::Done(Total(total))) = next.unwrap() {
-                ends.push((who, total));
+            match next {
+                (who, Ok(Item::Done(Total(total)))) => ends.push((who, total)),
+                (who, Err(e)) => panic!("{who} failed unexpectedly: {e}"),
+                _ => {}
             }
         }
         ends
@@ -417,6 +419,38 @@ async fn a_single_lane_session_serves_a_subscription() {
     drop(ticks);
     until(
         "cancellation must reach the producer on a shared lane",
+        || producers.load(SeqCst) == 0,
+    )
+    .await;
+}
+
+/// r[verify jetstream.subscription.surface.cancellation]
+/// A producer polled without a dispatcher still learns when its
+/// subscriber goes.
+///
+/// Serving in process — calling the service directly and polling what it
+/// returns — used to hand the producer a token nothing would ever
+/// cancel. Dropping the subscription woke nothing, and because
+/// `producing` runs its body in a spawned task, that task outlived the
+/// receiver it was sending to.
+#[tokio::test]
+async fn an_in_process_producer_is_cancelled_when_dropped() {
+    let counting = Counting {
+        ticks: broadcast::channel(64).0,
+        stop: subscription::CancellationToken::new(),
+        producers: Default::default(),
+        seen: Default::default(),
+    };
+    let producers = counting.producers.clone();
+
+    // No dispatcher anywhere: the service is called directly.
+    let mut ticks = counting.ticks(Context::default());
+    assert!(ticks.next().now_or_never().is_none(), "it starts");
+    until("the producer must start", || producers.load(SeqCst) == 1).await;
+
+    drop(ticks);
+    until(
+        "dropping it must stop the producer, dispatcher or not",
         || producers.load(SeqCst) == 0,
     )
     .await;

--- a/tests/subscriptions.rs
+++ b/tests/subscriptions.rs
@@ -150,33 +150,32 @@ async fn a_generated_subscription_delivers_many_items() {
     let mut ticks = wired.lane().await.ticks(Context::default());
     let bumper = wired.lane().await;
 
-    // A subscription opens when it is first polled, so nothing is on the
-    // wire yet — hence the settle after the first read below.
-    let first = tokio::spawn(async move {
-        let mut got = Vec::new();
-        while let Some(item) = ticks.next().await {
-            match item.unwrap() {
-                Item::Next(Tick(n)) => {
-                    got.push(n);
-                    if got.len() == 3 {
-                        break;
-                    }
-                }
-                Item::Done(_) => break,
-            }
-        }
-        got
-    });
-    settle().await;
+    // A subscription opens when it is first read, so without this the
+    // bumps below would happen before the service had heard of it.
+    ticks.establish().await;
+    // Even established, this subscription is on its own lane and the
+    // bumps are on another, so it is only *this* producer being live
+    // that makes the ticks arrive — see `until` below.
+    until("the producer must start", || {
+        wired.producers.load(SeqCst) == 1
+    })
+    .await;
 
     for _ in 0..3 {
         bumper.bump(Context::default()).await.unwrap();
     }
 
-    let got = tokio::time::timeout(Duration::from_secs(5), first)
-        .await
-        .expect("three items must arrive")
-        .unwrap();
+    let mut got = Vec::new();
+    while got.len() < 3 {
+        let item = tokio::time::timeout(Duration::from_secs(5), ticks.next())
+            .await
+            .expect("three items must arrive")
+            .expect("the subscription must not end");
+        match item.unwrap() {
+            Item::Next(Tick(n)) => got.push(n),
+            Item::Done(_) => panic!("ended early"),
+        }
+    }
     assert_eq!(got, vec![1, 2, 3]);
 }
 
@@ -189,10 +188,7 @@ async fn a_unary_call_works_on_a_lane_serving_a_subscription() {
     let wired = Wired::new();
     let channel = wired.lane().await;
     let mut ticks = channel.ticks(Context::default());
-
-    // Open it: nothing reaches the service until the stream is polled.
-    let opened = tokio::spawn(async move { ticks.next().await });
-    settle().await;
+    ticks.establish().await;
 
     let n = tokio::time::timeout(
         Duration::from_secs(5),
@@ -202,7 +198,7 @@ async fn a_unary_call_works_on_a_lane_serving_a_subscription() {
     .expect("the lane must still answer while a subscription is open")
     .unwrap();
     assert_eq!(n, 1);
-    opened.abort();
+    drop(ticks);
 }
 
 /// r[verify jetstream.subscription.cancel]
@@ -215,25 +211,19 @@ async fn dropping_a_generated_subscription_stops_the_producer() {
     let mut ticks = wired.lane().await.ticks(Context::default());
     let bumper = wired.lane().await;
 
-    let reading = tokio::spawn(async move {
-        let item = ticks.next().await;
-        // Hold it open until told otherwise.
-        (item, ticks)
-    });
-    settle().await;
-    bumper.bump(Context::default()).await.unwrap();
-
-    let (first, held) = tokio::time::timeout(Duration::from_secs(5), reading)
-        .await
-        .expect("the first item must arrive")
-        .unwrap();
-    assert!(matches!(first, Some(Ok(Item::Next(Tick(1))))));
+    ticks.establish().await;
     until("the producer must start", || {
         wired.producers.load(SeqCst) == 1
     })
     .await;
+    bumper.bump(Context::default()).await.unwrap();
 
-    drop(held);
+    let first = tokio::time::timeout(Duration::from_secs(5), ticks.next())
+        .await
+        .expect("the first item must arrive");
+    assert!(matches!(first, Some(Ok(Item::Next(Tick(1))))));
+
+    drop(ticks);
     until("dropping the subscription must stop the producer", || {
         wired.producers.load(SeqCst) == 0
     })
@@ -247,9 +237,19 @@ async fn dropping_a_generated_subscription_stops_the_producer() {
 #[tokio::test]
 async fn merging_keeps_the_result_and_says_whose() {
     let wired = Wired::new();
-    let one = wired.lane().await.ticks(Context::default());
-    let two = wired.lane().await.ticks(Context::default());
+    let mut one = wired.lane().await.ticks(Context::default());
+    let mut two = wired.lane().await.ticks(Context::default());
     let bumper = wired.lane().await;
+
+    one.establish().await;
+    two.establish().await;
+    until("both producers must start", || {
+        wired.producers.load(SeqCst) == 2
+    })
+    .await;
+
+    bumper.bump(Context::default()).await.unwrap();
+    bumper.bump(Context::default()).await.unwrap();
 
     let merged = subscription::merge([("one", one), ("two", two)]);
     let collecting = tokio::spawn(async move {
@@ -262,10 +262,6 @@ async fn merging_keeps_the_result_and_says_whose() {
         }
         ends
     });
-    settle().await;
-
-    bumper.bump(Context::default()).await.unwrap();
-    bumper.bump(Context::default()).await.unwrap();
     settle().await;
     wired.stop.cancel();
 
@@ -285,4 +281,143 @@ async fn unary_methods_are_unchanged() {
     let channel = wired.lane().await;
     assert_eq!(channel.bump(Context::default()).await.unwrap(), 1);
     assert_eq!(channel.bump(Context::default()).await.unwrap(), 2);
+}
+
+// ---------------------------------------------------------------------------
+// The same protocol on a session that has exactly one lane.
+//
+// r[verify jetstream.subscription.realisation]
+// r[verify jetstream.subscription.conformance.single-lane]
+// Everything above opens a lane per subscription, which is what a
+// `LaneSupport::Many` session licenses. On `LaneSupport::One` the same
+// code has to tag-multiplex two subscriptions and the unary calls onto
+// one lane — and the caller's types must not change, which is what makes
+// the realisation opaque rather than merely reported.
+
+/// Two subscriptions and a unary call, all on one lane.
+#[tokio::test]
+async fn one_lane_carries_two_subscriptions_and_a_call() {
+    let wired = Wired::new();
+    let channel = wired.lane().await;
+
+    let mut first = channel.ticks(Context::default());
+    let mut second = channel.ticks(Context::default());
+    // Both on the wire before anything is bumped. Without this the
+    // second one does not exist yet when the tick happens — a
+    // subscription opens on first read, and reading them in sequence
+    // opens them in sequence.
+    first.establish().await;
+    second.establish().await;
+
+    let reading = tokio::spawn(async move {
+        let (a, b) = futures::future::join(first.next(), second.next()).await;
+        (a, b, first, second)
+    });
+
+    // The lane is serving two subscriptions; it must still answer.
+    let n = tokio::time::timeout(
+        Duration::from_secs(5),
+        channel.bump(Context::default()),
+    )
+    .await
+    .expect("one lane must carry a call alongside its subscriptions")
+    .unwrap();
+    assert_eq!(n, 1);
+
+    let (a, b, first, second) =
+        tokio::time::timeout(Duration::from_secs(5), reading)
+            .await
+            .expect("both subscriptions must receive the tick")
+            .unwrap();
+    assert!(matches!(a, Some(Ok(Item::Next(Tick(1))))));
+    assert!(matches!(b, Some(Ok(Item::Next(Tick(1))))));
+    until("both producers must be alive", || {
+        wired.producers.load(SeqCst) == 2
+    })
+    .await;
+
+    // r[verify jetstream.subscription.identity]
+    // Cancelling one must not disturb the other, which share a lane and
+    // are told apart only by their tags.
+    drop(first);
+    until("dropping one must stop exactly one producer", || {
+        wired.producers.load(SeqCst) == 1
+    })
+    .await;
+
+    let mut second = second;
+    let reading = tokio::spawn(async move { second.next().await });
+    settle().await;
+    channel.bump(Context::default()).await.unwrap();
+    let still = tokio::time::timeout(Duration::from_secs(5), reading)
+        .await
+        .expect("the surviving subscription must still receive")
+        .unwrap();
+    assert!(matches!(still, Some(Ok(Item::Next(Tick(2))))));
+}
+
+/// The same subscription over a session that reports one lane and
+/// refuses a second — the caller's code is identical.
+#[tokio::test]
+async fn a_single_lane_session_serves_a_subscription() {
+    use jetstream_rpc::session::{
+        Capabilities, LaneSupport, SessionError, SingleLaneSession,
+    };
+
+    // One lane, borrowed from an in-process pair, then presented as the
+    // *only* lane each side has.
+    let pair = LocalSession::<CounterChannel>::pair();
+    let client_lane = Session::<CounterChannel>::open_lane(&pair.client)
+        .await
+        .expect("the pair is open");
+    let service_lane = Session::<CounterChannel>::accept_lane(&pair.server)
+        .await
+        .expect("the pair is open");
+
+    let one = SingleLaneSession::<CounterChannel, _, _>::client(client_lane);
+    let caps: Capabilities = Session::<CounterChannel>::capabilities(&one);
+    assert_eq!(caps.lanes, LaneSupport::One);
+
+    let counting = Counting {
+        ticks: broadcast::channel(64).0,
+        stop: subscription::CancellationToken::new(),
+        producers: Default::default(),
+        seen: Default::default(),
+    };
+    let producers = counting.producers.clone();
+    tokio::spawn(async move {
+        let mut service = CounterService { inner: counting };
+        let _ = jetstream_rpc::server::run(&mut service, service_lane).await;
+    });
+
+    let lane = Session::<CounterChannel>::open_lane(&one)
+        .await
+        .expect("the one lane is available");
+    let channel = CounterChannel::new(16, Box::new(lane));
+
+    // And there is no second one. A subscription on this session shares
+    // the lane with everything else, which the caller cannot see.
+    assert!(matches!(
+        Session::<CounterChannel>::open_lane(&one).await,
+        Err(SessionError::LaneLimitReached)
+    ));
+
+    let mut ticks = channel.ticks(Context::default());
+    ticks.establish().await;
+    channel.bump(Context::default()).await.unwrap();
+
+    let first = tokio::time::timeout(Duration::from_secs(5), ticks.next())
+        .await
+        .expect("a one-lane session must deliver a subscription");
+    assert!(matches!(first, Some(Ok(Item::Next(Tick(1))))));
+
+    // r[verify jetstream.subscription.cancel]
+    // Cancellation travels the subscription's own lane — which here is
+    // the only lane there is.
+    drop(ticks);
+    until(
+        "cancellation must reach the producer on a shared lane",
+        || producers.load(SeqCst) == 0,
+    )
+    .await;
 }

--- a/tests/subscriptions.rs
+++ b/tests/subscriptions.rs
@@ -455,3 +455,107 @@ async fn an_in_process_producer_is_cancelled_when_dropped() {
     )
     .await;
 }
+
+// ---------------------------------------------------------------------
+// A subscription whose producer fails partway through.
+// ---------------------------------------------------------------------
+
+#[service(uses(super::{Tick, Total}))]
+pub trait Flaky {
+    #[subscription]
+    fn flaky(&self, ctx: Context) -> Subscription<Tick, Total>;
+}
+
+use crate::flaky_protocol::{FlakyChannel, FlakyService};
+
+#[derive(Clone, Default)]
+struct Failing {
+    /// How many items the source was asked to produce. The whole point
+    /// of the test: it must stop at the failure and not one item later.
+    produced: Arc<AtomicUsize>,
+}
+
+impl Flaky for Failing {
+    fn flaky(&self, _ctx: Context) -> Subscription<Tick, Total> {
+        let produced = self.produced.clone();
+        Subscription::served(move |_cancel| {
+            futures::stream::unfold(0usize, move |n| {
+                let produced = produced.clone();
+                async move {
+                    produced.fetch_add(1, SeqCst);
+                    let item = match n {
+                        0 => Ok(Item::Next(Tick(1))),
+                        1 => Err(Error::new("the room burned down")),
+                        // Only reachable if the failure was not
+                        // terminal. Deliberately endless: a response
+                        // stream that keeps polling never stops, which
+                        // is the leak this guards.
+                        _ => Ok(Item::Next(Tick(99))),
+                    };
+                    Some((item, n + 1))
+                }
+            })
+        })
+    }
+}
+
+/// The session has to outlive the lane, so it is handed back rather
+/// than dropped at the end of the setup.
+async fn flaky_lane(
+) -> (LocalSession<FlakyChannel>, FlakyChannel, Arc<AtomicUsize>) {
+    let pair = LocalSession::<FlakyChannel>::pair();
+    let failing = Failing::default();
+    let produced = failing.produced.clone();
+    let server = pair.server.clone();
+    tokio::spawn(async move {
+        while let Ok(lane) = Session::<FlakyChannel>::accept_lane(&server).await
+        {
+            let inner = failing.clone();
+            tokio::spawn(async move {
+                let mut service = FlakyService { inner };
+                let _ = jetstream_rpc::server::run(&mut service, lane).await;
+            });
+        }
+    });
+    let lane = Session::<FlakyChannel>::open_lane(&pair.client)
+        .await
+        .expect("the session is open");
+    (pair.client, FlakyChannel::new(16, Box::new(lane)), produced)
+}
+
+/// r[verify jetstream.subscription.surface.termination]
+/// A producer failure is an *ending*. The dispatcher frees the tag when
+/// the response stream ends and nowhere else, so a failure that left the
+/// stream running would hold the tag for the life of the connection and
+/// deliver items after an error the subscriber had already seen.
+#[tokio::test]
+async fn a_producer_failure_ends_the_subscription() {
+    let (_session, channel, produced) = flaky_lane().await;
+    let mut items = channel.flaky(Context::default());
+
+    let first = tokio::time::timeout(Duration::from_secs(5), items.next())
+        .await
+        .expect("the first item must arrive")
+        .expect("the subscription must not end before it starts");
+    assert_eq!(
+        first.expect("the first item is not the failure"),
+        Item::Next(Tick(1)),
+    );
+
+    // The failure itself reaches the subscriber, rather than tearing
+    // down the lane the way a transport error would.
+    let second = tokio::time::timeout(Duration::from_secs(5), items.next())
+        .await
+        .expect("the failure must arrive")
+        .expect("the failure is an item, not the end of the stream");
+    assert!(second.is_err(), "expected the failure, got {second:?}");
+
+    // Give a source that kept running every chance to produce `Tick(99)`.
+    settle().await;
+    assert_eq!(
+        produced.load(SeqCst),
+        2,
+        "the source must be polled for the item and the failure, and \
+         then never again",
+    );
+}


### PR DESCRIPTION
Sixth in the subscriptions stack, on top of #698. The chat room on #698 was hand-written because `#[service]` couldn't generate it. Now it can — and making it generate it is what found everything below.

```rust
#[service]
pub trait Room {
    async fn post(&self, ctx: Context, who: String, body: String) -> Result<u64>;

    #[subscription]
    fn events(&self, ctx: Context, from: u64) -> Subscription<Event, Closed>;
}
```

That emits the item variant, the terminator, cancellation, and the four dispatcher hooks. A protocol with **no** subscriptions emits none of it — there's a test that asserts, by name, that none of `Cancel`, `RDONE`, `is_streaming`, `rpc_stream`, `cancelled_terminator` or `enum Done` appears.

### Four things the codegen could not do

**The trait signature has nowhere to put a cancellation token.** A caller needs a sequence; a producer needs to know its subscriber has gone; one trait describes both, and adding a token parameter would put something meaningless in the caller's signature. So a producer's subscription is a function *awaiting* its token, and the dispatcher supplies it when it serves the call — `Subscription::served`, or `Subscription::producing` for the common shape. Polled without a dispatcher it gets a token nothing cancels, which is the truth of that situation.

**A subscription cut short has no result**, and fabricating a `Default` would report one that didn't happen. The generated terminator gains a `Cancelled` variant under method id zero — which no method can have, since `MESSAGE_ID_START` is 102 — and the caller's sequence just ends. `Subscription::from_frames` now takes a decoder that can say "this frame ends it and carries nothing".

**The method is not `async`,** which the surface calls for and which acquiring a tag is not. A subscription opens on first poll. That has a consequence the example demonstrated the hard way: nothing reaches the service until something reads, and a subscription on its own lane is unordered against a call on another regardless. My first version of the room only forwarded live events, and `subscribe → post → read` deadlocked — reliably, in-process. The `from` cursor is not decoration; the room now keeps a log and replays from it, which is also what `subscription.surface.producer` requires of a producer surface.

**`#[subscription(lossy)]` is refused.** The datagram realisation hasn't landed, and accepting it would hand a reliable subscription to a caller who asked for a lossy one.

Two bugs the generated version exposed that the hand-written one had got right by accident: the channel's `Protocol` impl had no `tcancel` (so a dropped subscription told the service nothing — silently), and the room's producer let `closing` race `feed.recv()`, so a subscriber could miss the last message. `biased;` in the documented order is the rule — the terminator comes after every item already emitted.

### `cargo test -p jetstream_macros` did not compile

Not on this branch — on `main`. `prettyplease 0.3` pulls `syn 3` while the crate uses `syn 2`, so `prettyplease::unparse` gets the wrong `File`. **42 tests that could not run, and nine snapshots nothing was checking.** CI never caught it because `rust.yml` runs `cargo test -p jetstream`, not the workspace.

Pinned to `prettyplease 0.2`, which produces byte-identical formatting: the only snapshot change here is the `Arc` the channel now needs, because a subscription outlives the call that opened it. I checked that before regenerating them, precisely so the regeneration wasn't hiding drift.

### Verification

The whole workspace passes `cargo test --workspace --all-features` for the first time in this stack — 47 in `jetstream_macros`, 68 in `jetstream_rpc`, 5 new integration tests in `tests/subscriptions.rs`, everything else unchanged. Clippy clean on `--all-targets` bar three pre-existing warnings (`jetstream_wireformat`, `benches/perf.rs`, `examples/sqlite_mtls.rs`).

The integration tests live in `tests/`, which CI *does* run, and each was checked against a broken generator: removing the client's `tcancel` fails the cancellation test; declaring nothing streaming fails three. I also added `cargo run --example chat_room` next to the existing example steps in `rust.yml`, following what's already there for `session_lanes`.

```text
joined room-42
posted #1
  heard: ada says is anyone there?
  heard: ada says is anyone there?
  heard: ada says is anyone there?
producers alive: 3
producers alive after one left: 2
  grace heard: grace says here
  ada heard: grace says here
  grace's subscription closed at #2
  ada's subscription closed at #2
producers alive at the end: 0
```

Same output as the hand-written version, from a third of the code.

---
_Generated by [Claude Code](https://claude.ai/code/session_017u7J4fStrsu5W6CoXSw11t)_