### PR TITLE
fix: run CI on stacked PRs by dropping main-only pull_request filter

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -25,7 +25,6 @@ on:
       - "components/jetstream_wireformat/**"
       - ".github/workflows/bazel.yml"
   pull_request:
-    branches: ["main"]
     paths:
       - ".bazelrc"
       - "BUILD.bazel"

--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -3,8 +3,7 @@ name: Deploy mdBook site to Pages
 on:
   push:
     branches: ["main"]
-  pull_request:
-    branches: ["main"]
+  pull_request: {}
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/rust-clippy.yml
+++ b/.github/workflows/rust-clippy.yml
@@ -12,9 +12,7 @@ name: rust-clippy analyze
 on:
   push:
     branches: ["main"]
-  pull_request:
-    # The branches below must be a subset of the branches above
-    branches: ["main"]
+  pull_request: {}
   schedule:
     - cron: "35 19 * * 6"
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,7 +1,6 @@
 name: "Rust Matrix Build & Test"
 on:
-  pull_request:
-    branches: ["main"]
+  pull_request: {}
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -1,7 +1,6 @@
 name: "Swift Build & Test"
 on:
   pull_request:
-    branches: ["main"]
     paths:
       - "Sources/**"
       - "Tests/**"

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -1,7 +1,6 @@
 name: "TypeScript Build & Test"
 on:
   pull_request:
-    branches: ["main"]
     paths:
       - "packages/**"
       - "pnpm-workspace.yaml"


### PR DESCRIPTION
## Summary
- GitHub Actions matches a workflow's `pull_request.branches` filter against the PR's **base** branch, not its head. Stacked PRs (a PR whose base is another feature branch instead of `main`) therefore never triggered `rust.yml`, `rust-clippy.yml`, `swift.yml`, `typescript.yml`, `bazel.yml`, or `mdbook.yml`, since all of them restricted `pull_request` to `branches: ["main"]`.
- Dropped that restriction from each workflow's `pull_request` trigger so CI runs regardless of the PR's base branch. `push` triggers are untouched and remain `main`-only.

## Test plan
- [x] Validated all edited workflow YAML files parse correctly (`yaml.safe_load`)
- [ ] Confirm CI actually fires on a stacked PR against a non-`main` base once merged


---
_Generated by [Claude Code](https://claude.ai/code/session_01UF7NS91YcoRQiTNUfXHzG8)_